### PR TITLE
Fix rate in while loop

### DIFF
--- a/epick_bringup/urdf/epick_ros2_control.xacro
+++ b/epick_bringup/urdf/epick_ros2_control.xacro
@@ -12,7 +12,7 @@
         <param name="timeout">500</param>
 
         <!-- Gripper parameters. -->
-        <param name="lave_address">0x9</param>
+        <param name="slave_address">0x9</param>
         <param name="mode">AutomaticMode</param>
         <param name="max_vacuum_pressure">-100</param>
         <param name="min_vacuum_pressure">-10</param>
@@ -22,7 +22,7 @@
         <param name="use_dummy">false</param>
 
       </hardware>
-    
+
       <gpio name="gripper">
         <command_interface name="regulate"/>
         <state_interface name="regulate"/>

--- a/epick_description/urdf/epick_gripper_ros2_control.xacro
+++ b/epick_description/urdf/epick_gripper_ros2_control.xacro
@@ -12,7 +12,7 @@
         <param name="timeout">500</param>
 
         <!-- Gripper parameters. -->
-        <param name="lave_address">0x9</param>
+        <param name="slave_address">0x9</param>
         <param name="mode">AutomaticMode</param>
         <param name="max_vacuum_pressure">-100</param>
         <param name="min_vacuum_pressure">-10</param>
@@ -22,7 +22,7 @@
         <param name="use_dummy">true</param>
 
       </hardware>
-      
+
       <gpio name="gripper">
         <command_interface name="regulate"/>
         <state_interface name="object_detection_status"/>

--- a/epick_driver/include/epick_driver/driver.hpp
+++ b/epick_driver/include/epick_driver/driver.hpp
@@ -81,13 +81,13 @@ enum class ObjectDetectionStatus
 enum class GripperFaultStatus
 {
   NoFault,
-  AcionDelayed,
+  ActionDelayed,
   PorousMaterialDetected,
   GrippingTimeout,
   ActivationBitNotSet,
   MaximumTemperatureExceeded,
   NoCommunicationForAtLeastOneSecond,
-  UderMinimumOperatingVoltage,
+  UnderMinimumOperatingVoltage,
   AutomaticReleaseInProgress,
   InternalFault,
   AutomaticReleaseCompleted,

--- a/epick_driver/src/default_driver_utils.cpp
+++ b/epick_driver/src/default_driver_utils.cpp
@@ -32,6 +32,7 @@
 #include <cmath>
 #include <iostream>
 #include <map>
+#include <unordered_map>
 
 namespace epick_driver::default_driver_utils
 {

--- a/epick_driver/src/epick_gripper_hardware_interface.cpp
+++ b/epick_driver/src/epick_gripper_hardware_interface.cpp
@@ -297,9 +297,9 @@ void EpickGripperHardwareInterface::background_task()
       RCLCPP_ERROR(kLogger, "Check Epick Gripper connection and restart drivers. Error: %s", e.what());
       communication_thread_is_running_.store(false);
     }
-  }
 
-  std::this_thread::sleep_for(kCommandInterval);
+    std::this_thread::sleep_for(kCommandInterval);
+  }
 }
 }  // namespace epick_driver
 


### PR DESCRIPTION
The sleep got misplaced outside the `while` loop, probably due to merge conflict resolution.

This also fixes some typos in parameter and enum names.