### PR TITLE
Fix parsing address from string and parameter spelling

### DIFF
--- a/epick_driver/src/default_driver_factory.cpp
+++ b/epick_driver/src/default_driver_factory.cpp
@@ -44,7 +44,7 @@ namespace epick_driver
 const auto kLogger = rclcpp::get_logger("DefaultDriverFactory");
 
 constexpr auto kSlaveAddressParamName = "slave_address";
-constexpr auto kSlaveAddressParamDefault = 0x9;
+constexpr uint8_t kSlaveAddressParamDefault = 0x9;
 
 constexpr auto kModeParamName = "mode";
 constexpr auto kModeParamDefault = GripperMode::AutomaticMode;
@@ -65,9 +65,11 @@ std::unique_ptr<epick_driver::Driver>
 epick_driver::DefaultDriverFactory::create(const hardware_interface::HardwareInfo& info) const
 {
   RCLCPP_INFO(kLogger, "Reading slave_address...");
-  uint8_t slave_address = info.hardware_parameters.count(kSlaveAddressParamName) ?
-                              static_cast<uint8_t>(std::stoul(info.hardware_parameters.at(kSlaveAddressParamName))) :
-                              kSlaveAddressParamDefault;
+  // Convert base-16 address stored as a string (for example, "0x9") into an integer
+  const uint8_t slave_address =
+      info.hardware_parameters.count(kSlaveAddressParamName) ?
+          static_cast<uint8_t>(std::stoul(info.hardware_parameters.at(kSlaveAddressParamName), nullptr, 16)) :
+          kSlaveAddressParamDefault;
   RCLCPP_INFO(kLogger, "slave_address: %d", slave_address);
 
   RCLCPP_INFO(kLogger, "Reading mode...");

--- a/epick_driver/src/default_driver_utils.cpp
+++ b/epick_driver/src/default_driver_utils.cpp
@@ -331,12 +331,12 @@ GripperFaultStatus get_gripper_fault_status(uint8_t& reg)
     { 0b00000010, GripperFaultStatus::Unknown },                            // 0x2
     { 0b00000011, GripperFaultStatus::PorousMaterialDetected },             // 0x3
     { 0b00000100, GripperFaultStatus::Unknown },                            // 0x4
-    { 0b00000101, GripperFaultStatus::AcionDelayed },                       // 0x5
+    { 0b00000101, GripperFaultStatus::ActionDelayed },                       // 0x5
     { 0b00000110, GripperFaultStatus::GrippingTimeout },                    // 0x6
     { 0b00000111, GripperFaultStatus::ActivationBitNotSet },                // 0x7
     { 0b00001000, GripperFaultStatus::MaximumTemperatureExceeded },         // 0x8
     { 0b00001001, GripperFaultStatus::NoCommunicationForAtLeastOneSecond }, // 0x9
-    { 0b00001010, GripperFaultStatus::UderMinimumOperatingVoltage },        // 0xA
+    { 0b00001010, GripperFaultStatus::UnderMinimumOperatingVoltage },        // 0xA
     { 0b00001011, GripperFaultStatus::AutomaticReleaseInProgress },         // 0xB
     { 0b00001100, GripperFaultStatus::InternalFault },                      // 0xC
     { 0b00001101, GripperFaultStatus::Unknown },                            // 0xD
@@ -352,13 +352,13 @@ const std::string fault_status_to_string(const GripperFaultStatus fault_status)
   // clang-format off
   static std::map<GripperFaultStatus, std::string> map = {
     { GripperFaultStatus::NoFault, "NoFault" },
-    { GripperFaultStatus::AcionDelayed, "AcionDelayed" },
+    { GripperFaultStatus::ActionDelayed, "ActionDelayed" },
     { GripperFaultStatus::PorousMaterialDetected, "PorousMaterialDetected" },
     { GripperFaultStatus::GrippingTimeout, "GrippingTimeout" },
     { GripperFaultStatus::ActivationBitNotSet, "ActivationBitNotSet" },
     { GripperFaultStatus::MaximumTemperatureExceeded, "MaximumTemperatureExceeded" },
     { GripperFaultStatus::NoCommunicationForAtLeastOneSecond, "NoCommunicationForAtLeastOneSecond" },
-    { GripperFaultStatus::UderMinimumOperatingVoltage, "UderMinimumOperatingVoltage" },
+    { GripperFaultStatus::UnderMinimumOperatingVoltage, "UnderMinimumOperatingVoltage" },
     { GripperFaultStatus::AutomaticReleaseInProgress, "AutomaticReleaseInProgress" },
     { GripperFaultStatus::InternalFault, "InternalFault" },
     { GripperFaultStatus::AutomaticReleaseCompleted, "AutomaticReleaseCompleted" },

--- a/epick_driver/src/default_driver_utils.cpp
+++ b/epick_driver/src/default_driver_utils.cpp
@@ -331,12 +331,12 @@ GripperFaultStatus get_gripper_fault_status(uint8_t& reg)
     { 0b00000010, GripperFaultStatus::Unknown },                            // 0x2
     { 0b00000011, GripperFaultStatus::PorousMaterialDetected },             // 0x3
     { 0b00000100, GripperFaultStatus::Unknown },                            // 0x4
-    { 0b00000101, GripperFaultStatus::ActionDelayed },                       // 0x5
+    { 0b00000101, GripperFaultStatus::ActionDelayed },                      // 0x5
     { 0b00000110, GripperFaultStatus::GrippingTimeout },                    // 0x6
     { 0b00000111, GripperFaultStatus::ActivationBitNotSet },                // 0x7
     { 0b00001000, GripperFaultStatus::MaximumTemperatureExceeded },         // 0x8
     { 0b00001001, GripperFaultStatus::NoCommunicationForAtLeastOneSecond }, // 0x9
-    { 0b00001010, GripperFaultStatus::UnderMinimumOperatingVoltage },        // 0xA
+    { 0b00001010, GripperFaultStatus::UnderMinimumOperatingVoltage },       // 0xA
     { 0b00001011, GripperFaultStatus::AutomaticReleaseInProgress },         // 0xB
     { 0b00001100, GripperFaultStatus::InternalFault },                      // 0xC
     { 0b00001101, GripperFaultStatus::Unknown },                            // 0xD

--- a/epick_driver/urdf/test.urdf
+++ b/epick_driver/urdf/test.urdf
@@ -42,7 +42,7 @@
       <param name="timeout">500</param>
 
       <!-- Gripper parameters. -->
-      <param name="lave_address">0x9</param>
+      <param name="slave_address">0x9</param>
       <param name="mode">AutomaticMode</param>
       <param name="max_vacuum_pressure">-100</param>
       <param name="min_vacuum_pressure">-10</param>
@@ -52,7 +52,7 @@
       <param name="use_dummy">true</param>
 
     </hardware>
-    
+
     <gpio name="gripper">
       <command_interface name="regulate"/>
       <state_interface name="object_detection_status"/>


### PR DESCRIPTION
Follow-up to #2:
- Fixes lingering spelling errors that should have been added in #2.
- Fixes parsing slave address from hardware parameters (this fixes a bug that was exposed by fixing the spelling of the parameter name in the xacro).