### PR TITLE
Re-added headers to all CMakeFiles.txt.

### DIFF
--- a/epick_controllers/CMakeLists.txt
+++ b/epick_controllers/CMakeLists.txt
@@ -23,7 +23,10 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 
 # Epick controller library.
 
-add_library(epick_controllers SHARED
+add_library(
+  epick_controllers
+  SHARED
+  include/epick_controllers/epick_controller.hpp
   src/epick_controller.cpp
 )
 target_include_directories(

--- a/epick_driver/CMakeLists.txt
+++ b/epick_driver/CMakeLists.txt
@@ -31,6 +31,21 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 add_library(
     epick_driver
     SHARED
+    include/epick_driver/fake/fake_driver.hpp
+    include/epick_driver/crc_utils.hpp
+    include/epick_driver/data_utils.hpp
+    include/epick_driver/default_driver.hpp
+    include/epick_driver/default_driver_factory.hpp
+    include/epick_driver/default_driver_utils.hpp
+    include/epick_driver/default_serial.hpp
+    include/epick_driver/default_serial_factory.hpp
+    include/epick_driver/driver.hpp
+    include/epick_driver/driver_factory.hpp
+    include/epick_driver/epick_gripper_hardware_interface.hpp
+    include/epick_driver/hardware_interface_utils.hpp
+    include/epick_driver/serial.hpp
+    include/epick_driver/serial_factory.hpp
+    include/epick_driver/visibility_control.hpp
     src/epick_gripper_hardware_interface.cpp
     src/crc_utils.cpp
     src/data_utils.cpp

--- a/epick_driver/include/epick_driver/data_utils.hpp
+++ b/epick_driver/include/epick_driver/data_utils.hpp
@@ -53,6 +53,13 @@ std::string to_hex(const std::vector<uint8_t>& bytes);
 std::string to_hex(const std::vector<uint16_t>& bytes);
 
 /**
+ * Convert a byte to a binary representation for testing purposes.
+ * @param byte The byte to decode.
+ * @return The binary representation of the given byte.
+ */
+std::string uint8_to_binary_string(const uint8_t byte);
+
+/**
  * Get the Most Significant Byte (MSB) of the given value.
  * @param value A 16-bits value.
  * @return The Most Significant Byte (MSB) of the given value.

--- a/epick_driver/include/epick_driver/default_driver_utils.hpp
+++ b/epick_driver/include/epick_driver/default_driver_utils.hpp
@@ -58,7 +58,7 @@ enum class FunctionCode : uint8_t
  */
 void set_gripper_activation_action(uint8_t& reg, const GripperActivationAction gripper_activation_action);
 
-GripperActivationAction get_gripper_activation_action(uint8_t& reg);
+GripperActivationAction get_gripper_activation_action(const uint8_t &reg);
 
 /**
  * Convert a GripperActivationAction enum into a string.
@@ -83,7 +83,7 @@ void set_gripper_mode(uint8_t& reg, const GripperMode gripper_mode);
  * @param reg The register to read.
  * @param The gripper mode.
  */
-GripperMode get_gripper_mode(uint8_t& reg);
+GripperMode get_gripper_mode(const uint8_t &reg);
 
 /**
  * Convert a GripperMode enum into a string.
@@ -108,7 +108,7 @@ void set_gripper_regulate_action(uint8_t& reg, const GripperRegulateAction regul
  * @param reg The register to read.
  * @param The gripper regulate action.
  */
-GripperRegulateAction get_gripper_regulate_action(uint8_t& reg);
+GripperRegulateAction get_gripper_regulate_action(const uint8_t &reg);
 
 /**
  * Convert a GripperRegulateAction enum into a string.
@@ -158,7 +158,7 @@ const std::string gripper_release_action_to_string(const GripperReleaseAction gr
  * @param reg The register to read.
  * @param The gripper activations status.
  */
-GripperActivationStatus get_gripper_activation_status(uint8_t& reg);
+GripperActivationStatus get_gripper_activation_status(const uint8_t &reg);
 
 /**
  * Convert a GripperActivationStatus enum into a string.
@@ -176,7 +176,7 @@ const std::string gripper_activation_status_to_string(const GripperActivationSta
  * @param reg The register to read.
  * @param The object detection status.
  */
-ObjectDetectionStatus get_object_detection_status(uint8_t& reg);
+ObjectDetectionStatus get_object_detection_status(const uint8_t &reg);
 
 /**
  * Convert an ObjectDetection enum into a string.
@@ -201,7 +201,7 @@ double object_detection_to_double(const ObjectDetectionStatus object_detection);
  * @param reg The register to read.
  * @param The gripper fault status.
  */
-GripperFaultStatus get_gripper_fault_status(uint8_t& reg);
+GripperFaultStatus get_gripper_fault_status(const uint8_t &reg);
 
 /**
  * Convert a FaultStatus enum into a string.
@@ -219,7 +219,7 @@ const std::string fault_status_to_string(const GripperFaultStatus fault_status);
  * @param reg The register to read.
  * @param The gripper actuator status.
  */
-ActuatorStatus get_actuator_status(uint8_t& reg);
+ActuatorStatus get_actuator_status(const uint8_t &reg);
 
 /**
  * Convert a ActuatorStatus enum into a string.

--- a/epick_driver/src/data_utils.cpp
+++ b/epick_driver/src/data_utils.cpp
@@ -74,6 +74,16 @@ std::string to_hex(const std::vector<uint16_t>& bytes)
   return hex;
 }
 
+std::string uint8_to_binary_string(const uint8_t byte)
+{
+  std::string result = "0x";
+  for (int i = 7; i >= 0; --i)
+  {
+    result += ((byte >> i) & 1) ? '1' : '0';
+  }
+  return result;
+}
+
 uint8_t get_msb(uint16_t value)
 {
   return static_cast<uint8_t>(value >> 8) & 0xFF;

--- a/epick_driver/src/default_driver.cpp
+++ b/epick_driver/src/default_driver.cpp
@@ -168,7 +168,6 @@ void DefaultDriver::deactivate()
     0x00,  // Max absolute pressure.
     0x00,  // Gripper Timeout.
     0x00,  // Min absolute pressure
-
   };
   auto crc = crc_utils::compute_crc(request);
   request.push_back(data_utils::get_msb(crc));
@@ -188,6 +187,7 @@ void DefaultDriver::deactivate()
 
 void DefaultDriver::grip()
 {
+  RCLCPP_INFO(kLogger, "Gripping...");
   GripperStatus gripper_status = get_status();
   uint8_t action_request_register = 0b00000000;
   default_driver_utils::set_gripper_activation_action(action_request_register, gripper_status.gripper_activation_action);
@@ -220,6 +220,7 @@ void DefaultDriver::grip()
 
 void DefaultDriver::release()
 {
+  RCLCPP_INFO(kLogger, "Releasing...");
   GripperStatus gripper_status = get_status();
   uint8_t action_request_register = 0b00000000;
   default_driver_utils::set_gripper_activation_action(action_request_register, gripper_status.gripper_activation_action);

--- a/epick_driver/src/default_driver_utils.cpp
+++ b/epick_driver/src/default_driver_utils.cpp
@@ -73,7 +73,7 @@ void set_gripper_activation_action(uint8_t& reg, const GripperActivationAction g
   }
 }
 
-GripperActivationAction get_gripper_activation_action(uint8_t& reg)
+GripperActivationAction get_gripper_activation_action(const uint8_t& reg)
 {
   // clang-format off
   static const std::unordered_map<uint8_t, GripperActivationAction> map{
@@ -115,7 +115,7 @@ void set_gripper_mode(uint8_t& reg, const GripperMode gripper_mode)
   }
 }
 
-GripperMode get_gripper_mode(uint8_t& reg)
+GripperMode get_gripper_mode(const uint8_t& reg)
 {
   // clang-format off
   static const std::unordered_map<uint8_t, GripperMode> map{
@@ -159,7 +159,7 @@ void set_gripper_regulate_action(uint8_t& reg, const GripperRegulateAction regul
   }
 }
 
-GripperRegulateAction get_gripper_regulate_action(uint8_t& reg)
+GripperRegulateAction get_gripper_regulate_action(const uint8_t& reg)
 {
   // clang-format off
   static const std::unordered_map<uint8_t, GripperRegulateAction> map{
@@ -251,7 +251,7 @@ const std::string gripper_release_action_to_string(const GripperReleaseAction gr
 
 constexpr uint8_t gSTA_mask = 0b00110000;
 
-GripperActivationStatus get_gripper_activation_status(uint8_t& reg)
+GripperActivationStatus get_gripper_activation_status(const uint8_t& reg)
 {
   // clang-format off
   static const std::unordered_map<uint8_t, GripperActivationStatus> map{
@@ -280,7 +280,7 @@ const std::string gripper_activation_status_to_string(const GripperActivationSta
 
 constexpr uint8_t gOBJ_mask = 0b11000000;
 
-ObjectDetectionStatus get_object_detection_status(uint8_t& reg)
+ObjectDetectionStatus get_object_detection_status(const uint8_t& reg)
 {
   // clang-format off
   static const std::unordered_map<uint8_t, ObjectDetectionStatus> map{
@@ -322,7 +322,7 @@ double object_detection_to_double(const ObjectDetectionStatus object_detection)
 
 constexpr uint8_t gFLT_mask = 0b00001111;
 
-GripperFaultStatus get_gripper_fault_status(uint8_t& reg)
+GripperFaultStatus get_gripper_fault_status(const uint8_t& reg)
 {
   // clang-format off
   static const std::unordered_map<uint8_t, GripperFaultStatus> map{
@@ -374,7 +374,7 @@ const std::string fault_status_to_string(const GripperFaultStatus fault_status)
 
 constexpr uint8_t gVAS_mask = 0b00000011;
 
-ActuatorStatus get_actuator_status(uint8_t& reg)
+ActuatorStatus get_actuator_status(const uint8_t& reg)
 {
   // clang-format off
   static const std::unordered_map<uint8_t, ActuatorStatus> map{


### PR DESCRIPTION
I readded the headers file to the CMakeFiles.txt

It is not against any standard to have the headers declared in the CMakeFiles.txt. Not having makes my work on QtCreator more difficult.

I added a small function that I need to debug the register content on the server.
data_utils::uint8_to_binary_string