### PR TITLE
Fix serial errors halting control, and make gripper drop object when release is requested

### DIFF
--- a/epick_driver/src/default_driver.cpp
+++ b/epick_driver/src/default_driver.cpp
@@ -245,15 +245,6 @@ void DefaultDriver::release()
     RCLCPP_ERROR(kLogger, "Failed to release: %s", e.what());
     throw;
   }
-
-  // NOTE: messy workaround!
-  // Wait a short duration for the object to fall away from the gripper
-  std::this_thread::sleep_for(std::chrono::milliseconds{ 500 });
-
-  // After releaasing in automatic mode, the gripper needs to be deactivated and then reactivated.
-  deactivate();
-  std::this_thread::sleep_for(std::chrono::milliseconds{ 10 });
-  activate();
 }
 
 void DefaultDriver::set_slave_address(const uint8_t slave_address)

--- a/epick_driver/src/default_driver.cpp
+++ b/epick_driver/src/default_driver.cpp
@@ -186,10 +186,9 @@ void DefaultDriver::deactivate()
 void DefaultDriver::grip()
 {
   RCLCPP_INFO(kLogger, "Gripping...");
-  GripperStatus gripper_status = get_status();
   uint8_t action_request_register = 0b00000000;
-  default_driver_utils::set_gripper_activation_action(action_request_register, gripper_status.gripper_activation_action);
-  default_driver_utils::set_gripper_mode(action_request_register, gripper_status.gripper_mode);
+  default_driver_utils::set_gripper_activation_action(action_request_register, GripperActivationAction::Activate);
+  default_driver_utils::set_gripper_mode(action_request_register, GripperMode::AutomaticMode);
   default_driver_utils::set_gripper_regulate_action(action_request_register,
                                                     GripperRegulateAction::FollowRequestedVacuumParameters);
 
@@ -219,10 +218,9 @@ void DefaultDriver::grip()
 void DefaultDriver::release()
 {
   RCLCPP_INFO(kLogger, "Releasing...");
-  GripperStatus gripper_status = get_status();
   uint8_t action_request_register = 0b00000000;
-  default_driver_utils::set_gripper_activation_action(action_request_register, gripper_status.gripper_activation_action);
-  default_driver_utils::set_gripper_mode(action_request_register, gripper_status.gripper_mode);
+  default_driver_utils::set_gripper_activation_action(action_request_register, GripperActivationAction::Activate);
+  default_driver_utils::set_gripper_mode(action_request_register, GripperMode::AutomaticMode);
   default_driver_utils::set_gripper_regulate_action(action_request_register, GripperRegulateAction::StopVacuumGenerator);
 
   std::vector<uint8_t> request = { slave_address_,

--- a/epick_driver/src/epick_gripper_hardware_interface.cpp
+++ b/epick_driver/src/epick_gripper_hardware_interface.cpp
@@ -268,8 +268,14 @@ void EpickGripperHardwareInterface::background_task()
   {
     try
     {
-      // Depending on the current gripper status decide to send or not a regulate command.
+      // Retrieve current status and update state interfaces
       auto status = driver_->get_status();
+      safe_gripper_status_.object_detection_status.store(
+          default_driver_utils::object_detection_to_double(status.object_detection_status));
+      safe_gripper_status_.gripper_regulate_action.store(
+          default_driver_utils::regulate_action_to_double(status.gripper_regulate_action));
+
+      // Depending on the current gripper status decide to send or not a regulate command.
       auto regulate_action =
           default_driver_utils::double_to_regulate_action(safe_gripper_cmd_.gripper_regulate_action.load());
       if (status.gripper_regulate_action == GripperRegulateAction::StopVacuumGenerator &&
@@ -282,12 +288,6 @@ void EpickGripperHardwareInterface::background_task()
       {
         driver_->release();
       }
-
-      status = driver_->get_status();
-      safe_gripper_status_.object_detection_status.store(
-          default_driver_utils::object_detection_to_double(status.object_detection_status));
-      safe_gripper_status_.gripper_regulate_action.store(
-          default_driver_utils::regulate_action_to_double(status.gripper_regulate_action));
     }
     catch (serial::IOException& e)
     {

--- a/epick_driver/src/epick_gripper_hardware_interface.cpp
+++ b/epick_driver/src/epick_gripper_hardware_interface.cpp
@@ -292,9 +292,10 @@ void EpickGripperHardwareInterface::background_task()
     catch (serial::IOException& e)
     {
       RCLCPP_ERROR(kLogger, "Error: %s", e.what());
-      communication_thread_is_running_.store(false);
     }
   }
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
 }
 }  // namespace epick_driver
 

--- a/epick_driver/src/epick_gripper_hardware_interface.cpp
+++ b/epick_driver/src/epick_gripper_hardware_interface.cpp
@@ -36,8 +36,10 @@
 #include <pluginlib/class_list_macros.hpp>
 #include <rclcpp/logging.hpp>
 
+#include <chrono>
 #include <cmath>
 #include <optional>
+#include <thread>
 
 namespace epick_driver
 {
@@ -47,6 +49,8 @@ constexpr auto kGripperGPIO = "gripper";
 constexpr auto kRegulateCommandInterface = "regulate";
 constexpr auto kRegulateStateInterface = "regulate";
 constexpr auto kObjectDetectionStateInterface = "object_detection_status";
+
+constexpr auto kGripperCommsLoopPeriod = std::chrono::milliseconds{ 10 };
 
 EpickGripperHardwareInterface::EpickGripperHardwareInterface()
 {
@@ -263,31 +267,45 @@ hardware_interface::return_type EpickGripperHardwareInterface::write([[maybe_unu
 
 void EpickGripperHardwareInterface::background_task()
 {
-  // Read from and write to the gripper at 100 Hz.
+  // Read from and write to the gripper at a fixed rate set by kGripperCommsLoopPeriod.
   while (communication_thread_is_running_.load())
   {
     try
     {
       // Retrieve current status and update state interfaces
-      auto status = driver_->get_status();
+      const auto status = driver_->get_status();
       safe_gripper_status_.object_detection_status.store(
           default_driver_utils::object_detection_to_double(status.object_detection_status));
       safe_gripper_status_.gripper_regulate_action.store(
           default_driver_utils::regulate_action_to_double(status.gripper_regulate_action));
 
-      // Depending on the current gripper status decide to send or not a regulate command.
-      auto regulate_action =
+      // Given the command input and the current state of the gripper, decide what action to send.
+      const auto regulate_action =
           default_driver_utils::double_to_regulate_action(safe_gripper_cmd_.gripper_regulate_action.load());
+
+      // If the gripper's vacuum generator is not running and the command is to start regulating vacuum,
+      // tell the gripper to begin grasping.
       if (status.gripper_regulate_action == GripperRegulateAction::StopVacuumGenerator &&
           regulate_action == GripperRegulateAction::FollowRequestedVacuumParameters)
       {
         driver_->grip();
       }
-      if (status.gripper_regulate_action == GripperRegulateAction::FollowRequestedVacuumParameters &&
-          regulate_action == GripperRegulateAction::StopVacuumGenerator)
+      // If the vacuum generator is running and the command is to stop regulating vacuum,
+      // tell the gripper to release any currently-held object and turn off the vacuum generator.
+      else if (status.gripper_regulate_action == GripperRegulateAction::FollowRequestedVacuumParameters &&
+               regulate_action == GripperRegulateAction::StopVacuumGenerator)
       {
         driver_->release();
+
+        // NOTE: messy workaround!
+        // After releasing the object, wait a short duration for the object to fall away from the gripper.
+        std::this_thread::sleep_for(std::chrono::milliseconds{ 500 });
+
+        // The gripper then needs to be deactivated and then reactivated to reset for another grasp.
+        driver_->deactivate();
+        driver_->activate();
       }
+      // If neither of the above conditions are true, then send no command.
     }
     catch (serial::IOException& e)
     {
@@ -295,7 +313,7 @@ void EpickGripperHardwareInterface::background_task()
     }
   }
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  std::this_thread::sleep_for(kGripperCommsLoopPeriod);
 }
 }  // namespace epick_driver
 


### PR DESCRIPTION
- Restore sleep in `while` loop. We need this because otherwise that loop will just be called as quickly as the CPU can handle it, and not at the 100Hz loop rate we expect.
- Modify exception handling in the comms loop so if an exception is caught it does not totally stop the loop. This lets us continue controlling the gripper even if a call to read the gripper status from serial fails.
  - Note: this is a workaround to prevent this issue from making the gripper unusable -- we should still determine the root cause of that problem.
- Within `release()`, change the values written to the action request register to request `ReleaseWithoutTimeout` in addition to stopping the vacuum generator. This tells the gripper to open a valve and equalize pressure between the suction cup and ambient atmosphere, which causes the object to fall immediately instead of slowly as air leaks out.
- Reduce the number of places where serial status is being read. I think it's only necessary to request it once per loop.