### PR TITLE
Resending a command when the reponse doesn't arrive.

### DIFF
--- a/epick_bringup/urdf/epick_ros2_control.xacro
+++ b/epick_bringup/urdf/epick_ros2_control.xacro
@@ -9,7 +9,7 @@
        <!-- Serial connection parameters. -->
         <param name="usb_port">/dev/ttyUSB0</param>
         <param name="baud_rate">9600</param>
-        <param name="timeout">2000</param>
+        <param name="timeout">200</param>
 
         <!-- Gripper parameters. -->
         <param name="slave_address">0x9</param>

--- a/epick_driver/CMakeLists.txt
+++ b/epick_driver/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(
     include/epick_driver/default_serial.hpp
     include/epick_driver/default_serial_factory.hpp
     include/epick_driver/driver.hpp
+    include/epick_driver/driver_exception.hpp
     include/epick_driver/driver_factory.hpp
     include/epick_driver/epick_gripper_hardware_interface.hpp
     include/epick_driver/hardware_interface_utils.hpp

--- a/epick_driver/include/epick_driver/default_driver.hpp
+++ b/epick_driver/include/epick_driver/default_driver.hpp
@@ -69,6 +69,14 @@ public:
   void release() override;
 
 private:
+  /**
+   * Whith this command we send a request and wait for a response of given size.
+   * Behind the scene, if the response is not received, the software makes an attempt
+   * to resend the command up to 5 times before returning an empty response.
+   * @param request The command request.
+   * @param response_size The response expected size.
+   * @return The response or an empty vector if an en error occured.
+   */
   std::vector<uint8_t> send(const std::vector<uint8_t>& request, size_t response_size) const;
 
   std::unique_ptr<Serial> serial_ = nullptr;

--- a/epick_driver/include/epick_driver/default_driver.hpp
+++ b/epick_driver/include/epick_driver/default_driver.hpp
@@ -69,6 +69,8 @@ public:
   void release() override;
 
 private:
+  std::vector<uint8_t> send(const std::vector<uint8_t>& request, size_t response_size) const;
+
   std::unique_ptr<Serial> serial_ = nullptr;
   uint8_t slave_address_ = 0x00;
   GripperMode gripper_mode_ = GripperMode::AutomaticMode;

--- a/epick_driver/include/epick_driver/default_driver.hpp
+++ b/epick_driver/include/epick_driver/default_driver.hpp
@@ -75,7 +75,7 @@ private:
    * to resend the command up to 5 times before returning an empty response.
    * @param request The command request.
    * @param response_size The response expected size.
-   * @return The response or an empty vector if an en error occured.
+   * @return The response or an empty vector if an en error occurred.
    */
   std::vector<uint8_t> send(const std::vector<uint8_t>& request, size_t response_size) const;
 

--- a/epick_driver/include/epick_driver/driver_exception.hpp
+++ b/epick_driver/include/epick_driver/driver_exception.hpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022, Giovanni Remigi
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <exception>
+#include <string>
+#include <sstream>
+
+namespace epick_driver
+{
+class DriverException : public std::exception
+{
+  std::string what_;
+
+public:
+  explicit DriverException(const std::string& description)
+  {
+    std::stringstream ss;
+    ss << "DriverException: " << description << ".";
+    what_ = ss.str();
+  }
+
+  DriverException(const DriverException& other) : what_(other.what_)
+  {
+  }
+
+  ~DriverException() override = default;
+
+  // Disable copy constructors
+  DriverException& operator=(const DriverException&) = delete;
+
+  [[nodiscard]] const char* what() const throw() override
+  {
+    return what_.c_str();
+  }
+};
+}  // namespace epick_driver

--- a/epick_driver/src/default_driver.cpp
+++ b/epick_driver/src/default_driver.cpp
@@ -111,8 +111,8 @@ std::vector<uint8_t> DefaultDriver::send(const std::vector<uint8_t>& request, si
     }
     catch (const serial::IOException& e)
     {
-      RCLCPP_WARN(kLogger, "Attempt %d of %d: failed to communicate with the gripper: %s", retry_count + 1, kMaxRetries,
-                  e.what());
+      RCLCPP_WARN(kLogger, "Resending the command because the previous attempt (%d of %d) failed: %s", retry_count + 1,
+                  kMaxRetries, e.what());
       retry_count++;
     }
   }

--- a/epick_driver/src/default_driver.cpp
+++ b/epick_driver/src/default_driver.cpp
@@ -305,6 +305,7 @@ GripperStatus DefaultDriver::get_status()
     {
       serial_->write(request);
       response = serial_->read(kGetStatusResponseSize);
+      break;
     }
     catch (const serial::IOException& e)
     {

--- a/epick_driver/src/default_driver.cpp
+++ b/epick_driver/src/default_driver.cpp
@@ -31,6 +31,7 @@
 #include <epick_driver/crc_utils.hpp>
 #include <epick_driver/data_utils.hpp>
 #include <epick_driver/default_driver_utils.hpp>
+#include <epick_driver/driver_exception.hpp>
 
 #include <serial/serial.h>
 
@@ -176,8 +177,7 @@ void DefaultDriver::activate()
   auto response = send(request, kActivateResponseSize);
   if (response.empty())
   {
-    RCLCPP_ERROR(kLogger, "Failed to activate the gripper.");
-    throw;
+    throw DriverException{ "Failed to activate the gripper." };
   }
 }
 
@@ -205,8 +205,7 @@ void DefaultDriver::deactivate()
   auto response = send(request, kDectivateResponseSize);
   if (response.empty())
   {
-    RCLCPP_ERROR(kLogger, "Failed to deactivate the gripper.");
-    throw;
+    throw DriverException{ "Failed to deactivate the gripper." };
   }
 }
 
@@ -232,8 +231,7 @@ void DefaultDriver::grip()
   auto response = send(request, kGripResponseSize);
   if (response.empty())
   {
-    RCLCPP_ERROR(kLogger, "Failed to grip.");
-    throw;
+    throw DriverException{ "Failed to grip." };
   }
 }
 
@@ -259,8 +257,7 @@ void DefaultDriver::release()
   auto response = send(request, kReleaseResponseSize);
   if (response.empty())
   {
-    RCLCPP_ERROR(kLogger, "Failed to release.");
-    throw;
+    throw DriverException{ "Failed to release." };
   }
 }
 
@@ -312,8 +309,7 @@ GripperStatus DefaultDriver::get_status()
   auto response = send(request, kGetStatusResponseSize);
   if (response.empty())
   {
-    RCLCPP_ERROR(kLogger, "Failed to read the status.");
-    throw;
+    throw DriverException{ "Failed to read the status." };
   }
 
   // The content of the requested registers starts from byte 3.

--- a/epick_driver/src/default_serial.cpp
+++ b/epick_driver/src/default_serial.cpp
@@ -54,10 +54,6 @@ void DefaultSerial::close()
 
 std::vector<uint8_t> DefaultSerial::read(size_t size)
 {
-  if (!serial_->isOpen())
-  {
-    THROW(serial::IOException, "Trying to read but the port is disconnected.");
-  }
   std::vector<uint8_t> data;
   size_t bytes_read = serial_->read(data, size);
   if (bytes_read != size)
@@ -70,12 +66,8 @@ std::vector<uint8_t> DefaultSerial::read(size_t size)
 
 void DefaultSerial::write(const std::vector<uint8_t>& data)
 {
-  if (!serial_->isOpen())
-  {
-    THROW(serial::IOException, "Trying to write but the port is disconnected.");
-  }
   std::size_t num_bytes_written = serial_->write(data);
-  serial_->flush();
+  serial_->flushOutput();
   if (num_bytes_written != data.size())
   {
     const auto error_msg =

--- a/epick_driver/src/default_serial.cpp
+++ b/epick_driver/src/default_serial.cpp
@@ -54,6 +54,10 @@ void DefaultSerial::close()
 
 std::vector<uint8_t> DefaultSerial::read(size_t size)
 {
+  if (!serial_->isOpen())
+  {
+    THROW(serial::IOException, "Trying to read but the port is disconnected.");
+  }
   std::vector<uint8_t> data;
   size_t bytes_read = serial_->read(data, size);
   if (bytes_read != size)
@@ -66,6 +70,10 @@ std::vector<uint8_t> DefaultSerial::read(size_t size)
 
 void DefaultSerial::write(const std::vector<uint8_t>& data)
 {
+  if (!serial_->isOpen())
+  {
+    THROW(serial::IOException, "Trying to write but the port is disconnected.");
+  }
   std::size_t num_bytes_written = serial_->write(data);
   serial_->flush();
   if (num_bytes_written != data.size())

--- a/epick_driver/src/default_serial.cpp
+++ b/epick_driver/src/default_serial.cpp
@@ -67,7 +67,7 @@ std::vector<uint8_t> DefaultSerial::read(size_t size)
 void DefaultSerial::write(const std::vector<uint8_t>& data)
 {
   std::size_t num_bytes_written = serial_->write(data);
-  serial_->flushOutput();
+  serial_->flush();
   if (num_bytes_written != data.size())
   {
     const auto error_msg =

--- a/epick_driver/src/epick_gripper_hardware_interface.cpp
+++ b/epick_driver/src/epick_gripper_hardware_interface.cpp
@@ -200,7 +200,7 @@ EpickGripperHardwareInterface::on_activate([[maybe_unused]] const rclcpp_lifecyc
     communication_thread_is_running_.store(true);
     communication_thread_ = std::thread([this] { this->background_task(); });
   }
-  catch (const serial::IOException& e)
+  catch (const std::exception& e)
   {
     RCLCPP_FATAL(kLogger, "Failed to activate the Robotiq EPick gripper: %s", e.what());
     return CallbackReturn::ERROR;
@@ -307,7 +307,7 @@ void EpickGripperHardwareInterface::background_task()
       }
       // If neither of the above conditions are true, then send no command.
     }
-    catch (serial::IOException& e)
+    catch (std::exception& e)
     {
       RCLCPP_ERROR(kLogger, "Error: %s", e.what());
     }

--- a/epick_hardware_tests/CMakeLists.txt
+++ b/epick_hardware_tests/CMakeLists.txt
@@ -76,4 +76,14 @@ target_include_directories(release
 target_link_libraries(release epick_driver::epick_driver)
 ament_target_dependencies(release epick_driver)
 
+add_executable(break
+    src/break.cpp
+    src/command_line_utility.hpp
+    src/command_line_utility.cpp
+)
+target_include_directories(break
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(break epick_driver::epick_driver)
+ament_target_dependencies(break epick_driver)
+
 ament_package()

--- a/epick_hardware_tests/src/activate.cpp
+++ b/epick_hardware_tests/src/activate.cpp
@@ -146,7 +146,7 @@ int main(int argc, char* argv[])
 
     std::cout << "Checking if the gripper is connected..." << std::endl;
 
-    bool connected = driver->connect();
+    const bool connected = driver->connect();
     if (!connected)
     {
       std::cout << "The gripper is not connected" << std::endl;
@@ -162,7 +162,7 @@ int main(int argc, char* argv[])
 
     std::cout << "Reading the gripper status..." << std::endl;
 
-    epick_driver::GripperStatus status = driver->get_status();
+    const auto status = driver->get_status();
 
     std::cout << "Status retrieved:" << std::endl;
 

--- a/epick_hardware_tests/src/break.cpp
+++ b/epick_hardware_tests/src/break.cpp
@@ -28,7 +28,6 @@
 
 #include "epick_driver/default_driver.hpp"
 #include "epick_driver/default_serial.hpp"
-#include "epick_driver/default_driver_utils.hpp"
 
 #include "command_line_utility.hpp"
 
@@ -37,7 +36,10 @@
 #include <vector>
 #include <iostream>
 
-// This is a command to read the status of the gripper.
+// This command is used to reproduce an issue we have with writing and reading
+// on the serial port. It runs an infinite loop of write/read instructions and
+// stops if/when an error is encountered. It usually fails between 1 and 6
+// minutes.
 
 using namespace epick_driver;
 

--- a/epick_hardware_tests/src/break.cpp
+++ b/epick_hardware_tests/src/break.cpp
@@ -102,7 +102,7 @@ int main(int argc, char* argv[])
 
     std::cout << "Checking if the gripper is connected..." << std::endl;
 
-    bool connected = driver->connect();
+    const bool connected = driver->connect();
     if (!connected)
     {
       std::cout << "The gripper is not connected" << std::endl;
@@ -117,7 +117,7 @@ int main(int argc, char* argv[])
     std::cout << "The gripper is activated." << std::endl;
     std::cout << "Reading multiple times the gripper status..." << std::endl;
 
-    auto start = std::chrono::steady_clock::now();
+    const auto start = std::chrono::steady_clock::now();
 
     uint32_t counter = 0;
     bool ok = true;
@@ -135,10 +135,10 @@ int main(int argc, char* argv[])
       }
     }
 
-    auto end = std::chrono::steady_clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::seconds>(end - start);
-    int minutes = duration.count() / 60;
-    int seconds = duration.count() % 60;
+    const auto end = std::chrono::steady_clock::now();
+    const auto duration = std::chrono::duration_cast<std::chrono::seconds>(end - start);
+    const int minutes = duration.count() / 60;
+    const int seconds = duration.count() % 60;
 
     std::cout << "Execution time: " << minutes << "m:" << seconds << "s" << std::endl;
   }

--- a/epick_hardware_tests/src/break.cpp
+++ b/epick_hardware_tests/src/break.cpp
@@ -126,7 +126,7 @@ int main(int argc, char* argv[])
       try
       {
         counter++;
-        auto status = driver->get_status();
+        driver->get_status();
       }
       catch (serial::IOException& e)
       {

--- a/epick_hardware_tests/src/break.cpp
+++ b/epick_hardware_tests/src/break.cpp
@@ -115,19 +115,30 @@ int main(int argc, char* argv[])
     std::cout << "The gripper is activated." << std::endl;
     std::cout << "Reading multiple times the gripper status..." << std::endl;
 
+    auto start = std::chrono::steady_clock::now();
+
+    uint32_t counter = 0;
     bool ok = true;
     while (ok)
     {
       try
       {
+        counter++;
         auto status = driver->get_status();
       }
       catch (serial::IOException& e)
       {
         ok = false;
-        std::cout << "Error: " << e.what() << std::endl;
+        std::cout << "Error at " << counter << " iteration: " << e.what() << std::endl;
       }
     }
+
+    auto end = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::seconds>(end - start);
+    int minutes = duration.count() / 60;
+    int seconds = duration.count() % 60;
+
+    std::cout << "Execution time: " << minutes << "m:" << seconds << "s" << std::endl;
   }
   catch (const serial::IOException& e)
   {

--- a/epick_hardware_tests/src/break.cpp
+++ b/epick_hardware_tests/src/break.cpp
@@ -1,0 +1,139 @@
+// Copyright (c) 2022 PickNik, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "epick_driver/default_driver.hpp"
+#include "epick_driver/default_serial.hpp"
+#include "epick_driver/default_driver_utils.hpp"
+
+#include "command_line_utility.hpp"
+
+#include <chrono>
+#include <memory>
+#include <vector>
+#include <iostream>
+
+// This is a command to read the status of the gripper.
+
+using namespace epick_driver;
+
+constexpr auto kComPort = "/dev/ttyUSB0";
+constexpr auto kBaudRate = 115200;
+constexpr auto kTimeout = 500;  // milliseconds
+constexpr auto kSlaveAddress = 0x09;
+
+int main(int argc, char* argv[])
+{
+  CommandLineUtility cli;
+
+  std::string port = kComPort;
+  cli.registerHandler(
+      "--port", [&port](const char* value) { port = value; }, false);
+
+  int baudrate = kBaudRate;
+  cli.registerHandler(
+      "--baudrate", [&baudrate](const char* value) { baudrate = std::stoi(value); }, false);
+
+  int timeout = kTimeout;
+  cli.registerHandler(
+      "--timeout", [&timeout](const char* value) { timeout = std::stoi(value); }, false);
+
+  int slave_address = kSlaveAddress;
+  cli.registerHandler(
+      "--slave-address", [&slave_address](const char* value) { slave_address = std::stoi(value); }, false);
+
+  cli.registerHandler("-h", [&]() {
+    std::cout << "Usage: ./set_relative_pressure [OPTIONS]\n"
+              << "Options:\n"
+              << "  --port VALUE                 Set the com port (default " << kComPort << ")\n"
+              << "  --baudrate VALUE             Set the baudrate (default " << kBaudRate << "bps)\n"
+              << "  --timeout VALUE              Set the read/write timeout (default " << kTimeout << "ms)\n"
+              << "  --slave-address VALUE        Set the slave address (default " << kSlaveAddress << ")\n"
+              << "  -h                           Show this help message\n";
+    exit(0);
+  });
+
+  if (!cli.parse(argc, argv))
+  {
+    return 1;
+  }
+
+  try
+  {
+    auto serial = std::make_unique<DefaultSerial>();
+    serial->set_port(port);
+    serial->set_baudrate(baudrate);
+    serial->set_timeout(timeout);
+
+    auto driver = std::make_unique<DefaultDriver>(std::move(serial));
+    driver->set_slave_address(slave_address);
+
+    std::cout << "Using the following parameters: " << std::endl;
+    std::cout << " - port: " << port << std::endl;
+    std::cout << " - baudrate: " << baudrate << "bps" << std::endl;
+    std::cout << " - read/write timeut: " << timeout << "ms" << std::endl;
+    std::cout << " - slave address: " << slave_address << std::endl;
+
+    std::cout << "Checking if the gripper is connected..." << std::endl;
+
+    bool connected = driver->connect();
+    if (!connected)
+    {
+      std::cout << "The gripper is not connected" << std::endl;
+      return 1;
+    }
+
+    std::cout << "The gripper is connected." << std::endl;
+    std::cout << "Activating the gripper..." << std::endl;
+
+    driver->activate();
+
+    std::cout << "The gripper is activated." << std::endl;
+    std::cout << "Reading multiple times the gripper status..." << std::endl;
+
+    bool ok = true;
+    while (ok)
+    {
+      try
+      {
+        auto status = driver->get_status();
+      }
+      catch (serial::IOException& e)
+      {
+        ok = false;
+        std::cout << "Error: " << e.what() << std::endl;
+      }
+    }
+  }
+  catch (const serial::IOException& e)
+  {
+    std::cout << "Failed to communicating with the gripper:" << e.what();
+    return 1;
+  }
+
+  return 0;
+}

--- a/epick_hardware_tests/src/deactivate.cpp
+++ b/epick_hardware_tests/src/deactivate.cpp
@@ -146,7 +146,7 @@ int main(int argc, char* argv[])
 
     std::cout << "Checking if the gripper is connected..." << std::endl;
 
-    bool connected = driver->connect();
+    const bool connected = driver->connect();
     if (!connected)
     {
       std::cout << "The gripper is not connected" << std::endl;
@@ -162,7 +162,7 @@ int main(int argc, char* argv[])
 
     std::cout << "Reading the gripper status..." << std::endl;
 
-    epick_driver::GripperStatus status = driver->get_status();
+    const auto status = driver->get_status();
 
     std::cout << "Status retrieved:" << std::endl;
 

--- a/epick_hardware_tests/src/get_status.cpp
+++ b/epick_hardware_tests/src/get_status.cpp
@@ -100,7 +100,7 @@ int main(int argc, char* argv[])
 
     std::cout << "Checking if the gripper is connected..." << std::endl;
 
-    bool connected = driver->connect();
+    const bool connected = driver->connect();
     if (!connected)
     {
       std::cout << "The gripper is not connected" << std::endl;
@@ -110,7 +110,7 @@ int main(int argc, char* argv[])
     std::cout << "The gripper is connected." << std::endl;
     std::cout << "Reading the gripper status..." << std::endl;
 
-    epick_driver::GripperStatus status = driver->get_status();
+    const auto status = driver->get_status();
 
     std::cout << "Status retrieved:" << std::endl;
 


### PR DESCRIPTION
Sometimes, when we write a request to the gripper, the response does not arrive. If this happens we resend the command up to a maximum of 5 times before throwing an actual exception.

I added a test command called "break" to reproduce the problem by talking directly to the driver, instead of using the ros2_control framework. I wanted to prove that the issue is a serial communication problem and not a threading problem, or something else in the hardware interface.