### PR TITLE
Add action-based gripper controller

### DIFF
--- a/epick_controllers/CMakeLists.txt
+++ b/epick_controllers/CMakeLists.txt
@@ -6,6 +6,8 @@ project(epick_controllers VERSION 0.0.1 LANGUAGES CXX)
 # This module provides installation directories as per the GNU coding standards.
 include(GNUInstallDirs)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS true)
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
@@ -13,11 +15,17 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(controller_interface REQUIRED)
 find_package(epick_msgs REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_action REQUIRED)
+find_package(realtime_tools REQUIRED)
 find_package(std_srvs REQUIRED)
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   controller_interface
   epick_msgs
+  rclcpp
+  rclcpp_action
+  realtime_tools
   std_srvs
 )
 
@@ -27,7 +35,9 @@ add_library(
   epick_controllers
   SHARED
   include/epick_controllers/epick_controller.hpp
+  include/epick_controllers/epick_gripper_action_controller.hpp
   src/epick_controller.cpp
+  src/epick_gripper_action_controller.cpp
 )
 target_include_directories(
   epick_controllers

--- a/epick_controllers/CMakeLists.txt
+++ b/epick_controllers/CMakeLists.txt
@@ -36,8 +36,10 @@ add_library(
   SHARED
   include/epick_controllers/epick_controller.hpp
   include/epick_controllers/epick_gripper_action_controller.hpp
+  include/epick_controllers/epick_status_publisher_controller.hpp
   src/epick_controller.cpp
   src/epick_gripper_action_controller.cpp
+  src/epick_status_publisher_controller.cpp
 )
 target_include_directories(
   epick_controllers

--- a/epick_controllers/controller_plugins.xml
+++ b/epick_controllers/controller_plugins.xml
@@ -4,4 +4,9 @@
             This controller provides an interface to for the Robotiq Epick gripper.
         </description>
     </class>
+    <class name="epick_controllers/EpickGripperActionController" type="epick_controllers::EpickGripperActionController" base_class_type="controller_interface::ControllerInterface">
+        <description>
+
+        </description>
+    </class>
 </library>

--- a/epick_controllers/controller_plugins.xml
+++ b/epick_controllers/controller_plugins.xml
@@ -9,4 +9,9 @@
 
         </description>
     </class>
+    <class name="epick_controllers/EpickStatusPublisherController" type="epick_controllers::EpickStatusPublisherController" base_class_type="controller_interface::ControllerInterface">
+        <description>
+
+        </description>
+    </class>
 </library>

--- a/epick_controllers/include/epick_controllers/epick_controller.hpp
+++ b/epick_controllers/include/epick_controllers/epick_controller.hpp
@@ -31,7 +31,6 @@
 #include <controller_interface/controller_interface.hpp>
 #include <std_srvs/srv/set_bool.hpp>
 #include <std_msgs/msg/float64.hpp>
-#include <epick_msgs/msg/object_detection_status.hpp>
 
 namespace epick_controllers
 {
@@ -53,9 +52,6 @@ public:
 private:
   // When we send a true, the gripper will begin to grip, when false the gripper will release.
   rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr grip_srv_;
-
-  // Publishes the object detection status.
-  rclcpp::Publisher<epick_msgs::msg::ObjectDetectionStatus>::SharedPtr object_detection_status_pub_;
 
   // The logic of the server to control the gripper.
   bool grip_cmd(std_srvs::srv::SetBool::Request::SharedPtr request,

--- a/epick_controllers/include/epick_controllers/epick_gripper_action_controller.hpp
+++ b/epick_controllers/include/epick_controllers/epick_gripper_action_controller.hpp
@@ -28,14 +28,17 @@
 
 #pragma once
 
-#include <control_msgs/action/gripper_command.hpp>
-#include <controller_interface/controller_interface.hpp>
+#include <memory>
+#include <optional>
+
 #include <realtime_tools/realtime_buffer.h>
 #include <realtime_tools/realtime_server_goal_handle.h>
+
+#include <control_msgs/action/gripper_command.hpp>
+#include <controller_interface/controller_interface.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
 #include <std_srvs/srv/set_bool.hpp>
 #include <std_msgs/msg/float64.hpp>
-
-#include <rclcpp_action/rclcpp_action.hpp>
 
 namespace epick_controllers
 {

--- a/epick_controllers/include/epick_controllers/epick_gripper_action_controller.hpp
+++ b/epick_controllers/include/epick_controllers/epick_gripper_action_controller.hpp
@@ -49,7 +49,12 @@ public:
 
   struct Commands
   {
-    double regulate;
+    /**
+     * @brief Represents the binary flag send to the gripper hardware interface to actuate the vacuum gripper.
+     * @details If grip_cmd == 0.0, the gripper releases any held object. If grip_cmd == 1.0, the gripper activates its
+     * vacuum pump and attempts to grasp an object.
+     */
+    double grip_cmd;
   };
 
   controller_interface::InterfaceConfiguration command_interface_configuration() const override;

--- a/epick_controllers/include/epick_controllers/epick_gripper_action_controller.hpp
+++ b/epick_controllers/include/epick_controllers/epick_gripper_action_controller.hpp
@@ -44,6 +44,8 @@ class EpickGripperActionController : public controller_interface::ControllerInte
 public:
   using GripperCommandAction = control_msgs::action::GripperCommand;
   using GoalHandle = rclcpp_action::ServerGoalHandle<GripperCommandAction>;
+  using RealtimeGoalHandle = realtime_tools::RealtimeServerGoalHandle<control_msgs::action::GripperCommand>;
+  using RealtimeGoalHandleBuffer = realtime_tools::RealtimeBuffer<std::shared_ptr<RealtimeGoalHandle>>;
 
   struct Commands
   {
@@ -72,11 +74,19 @@ private:
 
   void preempt_active_goal();
 
+  void set_hold_position();
+
+  void check_for_success(const double current_regulate_state, const double current_regulate_command);
+
   std::optional<std::reference_wrapper<hardware_interface::LoanedCommandInterface>> regulate_command_interface_;
 
   std::optional<std::reference_wrapper<hardware_interface::LoanedStateInterface>> is_regulating_state_interface_;
 
   std::shared_ptr<rclcpp_action::Server<GripperCommandAction>> action_server_;
+
+  std::shared_ptr<rclcpp::TimerBase> goal_handle_timer_;
+
+  RealtimeGoalHandleBuffer rt_active_goal_;
 
   GripperCommandAction::Result::SharedPtr pre_alloc_result_;
 

--- a/epick_controllers/include/epick_controllers/epick_gripper_action_controller.hpp
+++ b/epick_controllers/include/epick_controllers/epick_gripper_action_controller.hpp
@@ -28,11 +28,11 @@
 
 #pragma once
 
-#include <memory>
-#include <optional>
-
 #include <realtime_tools/realtime_buffer.h>
 #include <realtime_tools/realtime_server_goal_handle.h>
+
+#include <memory>
+#include <optional>
 
 #include <control_msgs/action/gripper_command.hpp>
 #include <controller_interface/controller_interface.hpp>

--- a/epick_controllers/include/epick_controllers/epick_gripper_action_controller.hpp
+++ b/epick_controllers/include/epick_controllers/epick_gripper_action_controller.hpp
@@ -1,0 +1,88 @@
+// Copyright (c) 2023 PickNik, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <control_msgs/action/gripper_command.hpp>
+#include <controller_interface/controller_interface.hpp>
+#include <realtime_tools/realtime_buffer.h>
+#include <realtime_tools/realtime_server_goal_handle.h>
+#include <std_srvs/srv/set_bool.hpp>
+#include <std_msgs/msg/float64.hpp>
+
+#include <rclcpp_action/rclcpp_action.hpp>
+
+namespace epick_controllers
+{
+class EpickGripperActionController : public controller_interface::ControllerInterface
+{
+public:
+  using GripperCommandAction = control_msgs::action::GripperCommand;
+  using GoalHandle = rclcpp_action::ServerGoalHandle<GripperCommandAction>;
+
+  struct Commands
+  {
+    double regulate;
+  };
+
+  controller_interface::InterfaceConfiguration command_interface_configuration() const override;
+
+  controller_interface::InterfaceConfiguration state_interface_configuration() const override;
+
+  controller_interface::return_type update(const rclcpp::Time& time, const rclcpp::Duration& period) override;
+
+  CallbackReturn on_activate(const rclcpp_lifecycle::State& previous_state) override;
+
+  CallbackReturn on_deactivate(const rclcpp_lifecycle::State& previous_state) override;
+
+  CallbackReturn on_init() override;
+
+private:
+  rclcpp_action::GoalResponse goal_callback(const rclcpp_action::GoalUUID& uuid,
+                                            std::shared_ptr<const GripperCommandAction::Goal> goal);
+
+  rclcpp_action::CancelResponse cancel_callback(const std::shared_ptr<GoalHandle> goal_handle);
+
+  void accepted_callback(std::shared_ptr<GoalHandle> goal_handle);
+
+  void preempt_active_goal();
+
+  std::optional<std::reference_wrapper<hardware_interface::LoanedCommandInterface>> regulate_command_interface_;
+
+  std::optional<std::reference_wrapper<hardware_interface::LoanedStateInterface>> is_regulating_state_interface_;
+
+  std::shared_ptr<rclcpp_action::Server<GripperCommandAction>> action_server_;
+
+  GripperCommandAction::Result::SharedPtr pre_alloc_result_;
+
+  realtime_tools::RealtimeBuffer<Commands> commands_buffer_;
+
+  Commands commands_;
+  Commands commands_rt_;
+};
+}  // namespace epick_controllers

--- a/epick_controllers/include/epick_controllers/epick_status_publisher_controller.hpp
+++ b/epick_controllers/include/epick_controllers/epick_status_publisher_controller.hpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2023 PickNik, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <controller_interface/controller_interface.hpp>
+#include <std_msgs/msg/float64.hpp>
+#include <epick_msgs/msg/object_detection_status.hpp>
+
+namespace epick_controllers
+{
+class EpickStatusPublisherController : public controller_interface::ControllerInterface
+{
+public:
+  controller_interface::InterfaceConfiguration command_interface_configuration() const override;
+
+  controller_interface::InterfaceConfiguration state_interface_configuration() const override;
+
+  controller_interface::return_type update(const rclcpp::Time& time, const rclcpp::Duration& period) override;
+
+  CallbackReturn on_activate(const rclcpp_lifecycle::State& previous_state) override;
+
+  CallbackReturn on_deactivate(const rclcpp_lifecycle::State& previous_state) override;
+
+  CallbackReturn on_init() override;
+
+private:
+  rclcpp::Publisher<epick_msgs::msg::ObjectDetectionStatus>::SharedPtr object_detection_status_pub_;
+};
+}  // namespace epick_controllers

--- a/epick_controllers/package.xml
+++ b/epick_controllers/package.xml
@@ -12,6 +12,10 @@
 
   <depend>controller_interface</depend>
   <depend>epick_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_action</depend>
+  <depend>realtime_tools</depend>
+
   <depend>std_srvs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/epick_controllers/src/epick_gripper_action_controller.cpp
+++ b/epick_controllers/src/epick_gripper_action_controller.cpp
@@ -162,8 +162,8 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn EpickG
 }
 
 rclcpp_action::GoalResponse
-EpickGripperActionController::goal_callback(const rclcpp_action::GoalUUID& uuid,
-                                            std::shared_ptr<const GripperCommandAction::Goal> goal)
+EpickGripperActionController::goal_callback([[maybe_unused]] const rclcpp_action::GoalUUID& uuid,
+                                            [[maybe_unused]] std::shared_ptr<const GripperCommandAction::Goal> goal)
 {
   return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
 }

--- a/epick_controllers/src/epick_gripper_action_controller.cpp
+++ b/epick_controllers/src/epick_gripper_action_controller.cpp
@@ -1,0 +1,220 @@
+// Copyright (c) 2023 PickNik, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <algorithm>
+#include <epick_controllers/epick_gripper_action_controller.hpp>
+#include <optional>
+#include "hardware_interface/loaned_command_interface.hpp"
+#include "hardware_interface/loaned_state_interface.hpp"
+
+namespace
+{
+// auto findCommandInterface(const std::vector<hardware_interface::LoanedCommandInterface>& command_interfaces, const
+// std::string& name)
+// {
+//   auto interface_it = std::find_if(command_interfaces.cbegin(), command_interfaces.cend(), [&name](const
+//   hardware_interface::LoanedCommandInterface& interface){ return interface.get_interface_name() == name; }); if
+//   (interface_it == command_interfaces.cend())
+//   {
+//     return std::nullopt;
+//   }
+//   return interface_it;
+// }
+}
+
+namespace epick_controllers
+{
+enum CommandInterfaces : size_t
+{
+  REGULATE_GRIPPER_CMD = 0
+};
+
+enum StateInterfaces : size_t
+{
+  OBJECT_DETECTION_STATUS = 0
+};
+
+constexpr auto kRegulateCommandInterface = "gripper/regulate";
+constexpr auto kIsRegulatingStateInterface = "gripper/regulate";
+constexpr auto kObjectDetectionStateInterface = "gripper/object_detection_status";
+
+constexpr auto kRegulateService = "/regulate";
+constexpr auto kObjectDetectionStatusTopic = "/object_detection_status";
+
+controller_interface::InterfaceConfiguration EpickGripperActionController::command_interface_configuration() const
+{
+  controller_interface::InterfaceConfiguration config;
+  config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
+  config.names.emplace_back(kRegulateCommandInterface);
+  return config;
+}
+
+controller_interface::InterfaceConfiguration EpickGripperActionController::state_interface_configuration() const
+{
+  controller_interface::InterfaceConfiguration config;
+  config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
+  config.names.emplace_back(kIsRegulatingStateInterface, kObjectDetectionStateInterface);
+  return config;
+}
+
+controller_interface::return_type EpickGripperActionController::update([[maybe_unused]] const rclcpp::Time& time,
+                                                                       [[maybe_unused]] const rclcpp::Duration& period)
+{
+  // double object_detection_status = state_interfaces_[OBJECT_DETECTION_STATUS].get_value();
+  // auto object_detection_status_msg = std::make_shared<epick_msgs::msg::ObjectDetectionStatus>();
+
+  // if (object_detection_status < 0.5)
+  // {
+  //   object_detection_status_msg->status = object_detection_status_msg->UNKNOWN;
+  // }
+  // else if (object_detection_status < 1.5)
+  // {
+  //   object_detection_status_msg->status = object_detection_status_msg->OBJECT_DETECTED_AT_MIN_PRESSURE;
+  // }
+  // else if (object_detection_status < 2.5)
+  // {
+  //   object_detection_status_msg->status = object_detection_status_msg->OBJECT_DETECTED_AT_MAX_PRESSURE;
+  // }
+  // else if (object_detection_status < 3.5)
+  // {
+  //   object_detection_status_msg->status = object_detection_status_msg->NO_OBJECT_DETECTED;
+  // }
+  // else
+  // {
+  //   object_detection_status_msg->status = object_detection_status_msg->UNKNOWN;
+  // }
+
+  // object_detection_status_pub_->publish(*object_detection_status_msg);
+
+  return controller_interface::return_type::OK;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+EpickGripperActionController::on_activate([[maybe_unused]] const rclcpp_lifecycle::State& previous_state)
+{
+  auto regulate_command_interface_it = std::find_if(command_interfaces_.begin(), command_interfaces_.end(),
+                                                    [](const hardware_interface::LoanedCommandInterface& interface) {
+                                                      return interface.get_interface_name() == "regulate";
+                                                    });
+  if (regulate_command_interface_it == command_interfaces_.end())
+  {
+    return controller_interface::CallbackReturn::ERROR;
+  }
+  regulate_command_interface_ = *regulate_command_interface_it;
+
+  auto is_regulating_state_interface_it = std::find_if(state_interfaces_.begin(), state_interfaces_.end(),
+                                                       [](const hardware_interface::LoanedStateInterface& interface) {
+                                                         return interface.get_interface_name() == "regulate";
+                                                       });
+  if (is_regulating_state_interface_it == state_interfaces_.end())
+  {
+    return controller_interface::CallbackReturn::ERROR;
+  }
+  is_regulating_state_interface_ = *is_regulating_state_interface_it;
+
+  commands_.regulate = regulate_command_interface_->get().get_value();
+
+  commands_buffer_.initRT(commands_);
+
+  pre_alloc_result_ = std::make_shared<GripperCommandAction::Result>();
+  pre_alloc_result_->position = commands_.regulate;
+  pre_alloc_result_->reached_goal = false;
+  pre_alloc_result_->stalled = false;
+
+  action_server_ = rclcpp_action::create_server<GripperCommandAction>(
+      get_node(), "~/gripper_cmd",
+      [this](const rclcpp_action::GoalUUID& uuid, std::shared_ptr<const GripperCommandAction::Goal> goal) {
+        return goal_callback(uuid, goal);
+      },
+      [this](const std::shared_ptr<GoalHandle> goal_handle) { return cancel_callback(goal_handle); },
+      [this](std::shared_ptr<GoalHandle> goal_handle) { return accepted_callback(goal_handle); });
+
+  return LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+EpickGripperActionController::on_deactivate([[maybe_unused]] const rclcpp_lifecycle::State& previous_state)
+{
+  // try
+  // {
+  //   regulate_gripper_srv_.reset();
+  // }
+  // catch (...)
+  // {
+  //   return LifecycleNodeInterface::CallbackReturn::ERROR;
+  // }
+  return LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn EpickGripperActionController::on_init()
+{
+  return LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+// bool EpickGripperActionController::regulate_gripper(std_srvs::srv::SetBool::Request::SharedPtr request,
+//                                        [[maybe_unused]] std_srvs::srv::SetBool::Response::SharedPtr response)
+// {
+//   // command_interfaces_[REGULATE_GRIPPER_CMD].set_value(request->data ? 1.0 : 0.0);
+
+//   // TODO: read the response.
+//   //  resp->success = command_interfaces_[1].get_value();
+
+//   //  while (command_interfaces_[REACTIVATE_GRIPPER_RESPONSE].get_value() == ASYNC_WAITING) {
+//   //    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+//   //  }
+//   //  resp->success = command_interfaces_[REACTIVATE_GRIPPER_RESPONSE].get_value();
+
+//   //  return resp->success;
+//   return true;
+// }
+
+rclcpp_action::GoalResponse
+EpickGripperActionController::goal_callback(const rclcpp_action::GoalUUID& uuid,
+                                            std::shared_ptr<const GripperCommandAction::Goal> goal)
+{
+  return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
+}
+
+rclcpp_action::CancelResponse
+EpickGripperActionController::cancel_callback(const std::shared_ptr<GoalHandle> goal_handle)
+{
+}
+
+void EpickGripperActionController::accepted_callback(std::shared_ptr<GoalHandle> goal_handle)
+{
+}
+
+void EpickGripperActionController::preempt_active_goal()
+{
+}
+
+}  // namespace epick_controllers
+
+#include "pluginlib/class_list_macros.hpp"
+
+PLUGINLIB_EXPORT_CLASS(epick_controllers::EpickGripperActionController, controller_interface::ControllerInterface)

--- a/epick_controllers/src/epick_gripper_action_controller.cpp
+++ b/epick_controllers/src/epick_gripper_action_controller.cpp
@@ -28,14 +28,13 @@
 
 #include <epick_controllers/epick_gripper_action_controller.hpp>
 
-#include <rclcpp/logging.hpp>
-#include <hardware_interface/loaned_command_interface.hpp>
-#include <hardware_interface/loaned_state_interface.hpp>
-
 #include <algorithm>
 #include <chrono>
 #include <limits>
-#include <optional>
+
+#include <rclcpp/logging.hpp>
+#include <hardware_interface/loaned_command_interface.hpp>
+#include <hardware_interface/loaned_state_interface.hpp>
 
 namespace epick_controllers
 {

--- a/epick_controllers/src/epick_gripper_action_controller.cpp
+++ b/epick_controllers/src/epick_gripper_action_controller.cpp
@@ -97,6 +97,8 @@ controller_interface::return_type EpickGripperActionController::update([[maybe_u
 
   check_for_success(current_state, current_command);
 
+  regulate_command_interface_->get().set_value(current_command);
+
   return controller_interface::return_type::OK;
 }
 

--- a/epick_controllers/src/epick_status_publisher_controller.cpp
+++ b/epick_controllers/src/epick_status_publisher_controller.cpp
@@ -35,7 +35,6 @@ namespace state
 enum StateInterfaces : size_t
 {
   OBJECT_DETECTION_STATUS = 0
-
 };
 }
 

--- a/epick_controllers/src/epick_status_publisher_controller.cpp
+++ b/epick_controllers/src/epick_status_publisher_controller.cpp
@@ -1,0 +1,131 @@
+// Copyright (c) 2023 PickNik, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <epick_controllers/epick_status_publisher_controller.hpp>
+
+namespace epick_controllers
+{
+namespace state
+{
+enum StateInterfaces : size_t
+{
+  OBJECT_DETECTION_STATUS = 0
+
+};
+}
+
+constexpr auto kObjectDetectionStateInterface = "gripper/object_detection_status";
+
+constexpr auto kObjectDetectionStatusTopic = "/object_detection_status";
+
+controller_interface::InterfaceConfiguration EpickStatusPublisherController::command_interface_configuration() const
+{
+  controller_interface::InterfaceConfiguration config;
+  config.type = controller_interface::interface_configuration_type::NONE;
+  return config;
+}
+
+controller_interface::InterfaceConfiguration EpickStatusPublisherController::state_interface_configuration() const
+{
+  controller_interface::InterfaceConfiguration config;
+  config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
+  config.names.emplace_back(kObjectDetectionStateInterface);
+  return config;
+}
+
+controller_interface::return_type EpickStatusPublisherController::update([[maybe_unused]] const rclcpp::Time& time,
+                                                                         [[maybe_unused]] const rclcpp::Duration& period)
+{
+  double object_detection_status = state_interfaces_[state::OBJECT_DETECTION_STATUS].get_value();
+  auto object_detection_status_msg = std::make_shared<epick_msgs::msg::ObjectDetectionStatus>();
+
+  if (object_detection_status < 0.5)
+  {
+    object_detection_status_msg->status = object_detection_status_msg->UNKNOWN;
+  }
+  else if (object_detection_status < 1.5)
+  {
+    object_detection_status_msg->status = object_detection_status_msg->OBJECT_DETECTED_AT_MIN_PRESSURE;
+  }
+  else if (object_detection_status < 2.5)
+  {
+    object_detection_status_msg->status = object_detection_status_msg->OBJECT_DETECTED_AT_MAX_PRESSURE;
+  }
+  else if (object_detection_status < 3.5)
+  {
+    object_detection_status_msg->status = object_detection_status_msg->NO_OBJECT_DETECTED;
+  }
+  else
+  {
+    object_detection_status_msg->status = object_detection_status_msg->UNKNOWN;
+  }
+
+  object_detection_status_pub_->publish(*object_detection_status_msg);
+
+  return controller_interface::return_type::OK;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+EpickStatusPublisherController::on_activate([[maybe_unused]] const rclcpp_lifecycle::State& previous_state)
+{
+  try
+  {
+    object_detection_status_pub_ =
+        get_node()->create_publisher<epick_msgs::msg::ObjectDetectionStatus>(kObjectDetectionStatusTopic, 10);
+  }
+  catch (...)
+  {
+    return LifecycleNodeInterface::CallbackReturn::ERROR;
+  }
+  return LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+EpickStatusPublisherController::on_deactivate([[maybe_unused]] const rclcpp_lifecycle::State& previous_state)
+{
+  try
+  {
+    object_detection_status_pub_.reset();
+  }
+  catch (...)
+  {
+    return LifecycleNodeInterface::CallbackReturn::ERROR;
+  }
+  return LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn EpickStatusPublisherController::on_init()
+{
+  return LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+}  // namespace epick_controllers
+
+#include "pluginlib/class_list_macros.hpp"
+
+PLUGINLIB_EXPORT_CLASS(epick_controllers::EpickStatusPublisherController, controller_interface::ControllerInterface)

--- a/epick_description/config/controllers.yaml
+++ b/epick_description/config/controllers.yaml
@@ -5,5 +5,5 @@ controller_manager:
   ros__parameters:
     update_rate: 30 # Hz
 
-    epick_controller:
-      type: epick_controllers/EpickController
+    epick_gripper_action_controller:
+      type: epick_controllers/EpickGripperActionController

--- a/epick_description/config/controllers.yaml
+++ b/epick_description/config/controllers.yaml
@@ -7,3 +7,5 @@ controller_manager:
 
     epick_gripper_action_controller:
       type: epick_controllers/EpickGripperActionController
+    epick_status_publisher_controller:
+      type: epick_controllers/EpickStatusPublisherController

--- a/epick_description/launch/epick_gripper.launch.py
+++ b/epick_description/launch/epick_gripper.launch.py
@@ -93,7 +93,7 @@ def launch_setup(context, *args, **kwargs):
     epick_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["epick_controller", "-c", "/controller_manager"],
+        arguments=["epick_gripper_action_controller", "-c", "/controller_manager"],
     )
 
     # robot_state_publisher uses the URDF specified by the parameter robot_description

--- a/epick_description/launch/epick_gripper.launch.py
+++ b/epick_description/launch/epick_gripper.launch.py
@@ -96,6 +96,12 @@ def launch_setup(context, *args, **kwargs):
         arguments=["epick_gripper_action_controller", "-c", "/controller_manager"],
     )
 
+    epick_status_controller_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=["epick_status_publisher_controller", "-c", "/controller_manager"],
+    )
+
     # robot_state_publisher uses the URDF specified by the parameter robot_description
     # and the joint positions from the topic /joint_states to calculate the forward
     # kinematics of the robot and publish the results via tf.
@@ -110,6 +116,7 @@ def launch_setup(context, *args, **kwargs):
     nodes_to_start = [
         controller_manager,
         epick_controller_spawner,
+        epick_status_controller_spawner,
         robot_state_publisher_node,
     ]
     return nodes_to_start

--- a/epick_description/urdf/epick_driver_ros2_control.xacro
+++ b/epick_description/urdf/epick_driver_ros2_control.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="epick_driver_ros2_control" params="name">
+  <xacro:macro name="epick_driver_ros2_control" params="name use_fake_hardware:=true">
 
     <ros2_control name="${name}" type="system">
       <hardware>
@@ -15,7 +15,7 @@
         <!-- Gripper parameters /////////////////////////////////////////// -->
 
         <!-- Set use_dummy to true to connect to a dummy driver for testing purposes. -->
-        <param name="use_dummy">false</param>
+        <param name="use_dummy">${use_fake_hardware}</param>
 
         <!-- The address of the gripper. -->
         <param name="slave_address">0x9</param>

--- a/epick_description/urdf/epick_driver_ros2_control.xacro
+++ b/epick_description/urdf/epick_driver_ros2_control.xacro
@@ -15,7 +15,7 @@
         <!-- Gripper parameters /////////////////////////////////////////// -->
 
         <!-- Set use_dummy to true to connect to a dummy driver for testing purposes. -->
-        <param name="use_dummy">${use_fake_hardware}</param>
+        <param name="use_dummy">false</param>
 
         <!-- The address of the gripper. -->
         <param name="slave_address">0x9</param>

--- a/epick_description/urdf/epick_driver_ros2_control.xacro
+++ b/epick_description/urdf/epick_driver_ros2_control.xacro
@@ -1,6 +1,16 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="epick_driver_ros2_control" params="name use_fake_hardware:=true">
+  <xacro:macro name="epick_driver_ros2_control"
+               params="name use_fake_hardware:=true
+                       usb_port:=/dev/ttyUSB0
+                       baud_rate:=115200
+                       timeout:=0.2
+                       slave_address:=0x9
+                       mode:=AdvancedMode
+                       grip_max_vacuum_pressure:=-60
+                       grip_min_vacuum_pressure:=-10
+                       grip_timeout:=25.0
+                       release_timeout:=2.0">
 
     <ros2_control name="${name}" type="system">
       <hardware>
@@ -8,9 +18,9 @@
 
        <!-- Serial connection parameters ////////////////////////////////// -->
 
-        <param name="usb_port">/dev/ttyUSB0</param>
-        <param name="baud_rate">115200</param>
-        <param name="timeout">0.2</param>
+        <param name="usb_port">${usb_port}</param>
+        <param name="baud_rate">${baud_rate}</param>
+        <param name="timeout">${timeout}</param>
 
         <!-- Gripper parameters /////////////////////////////////////////// -->
 
@@ -18,16 +28,16 @@
         <param name="use_dummy">${use_fake_hardware}</param>
 
         <!-- The address of the gripper. -->
-        <param name="slave_address">0x9</param>
+        <param name="slave_address">${slave_address}</param>
 
         <!-- The gripper operation mode: AutomaticMode or AdvancedMode. -->
-        <param name="mode">AdvancedMode</param>
+        <param name="mode">${mode}</param>
 
         <!-- The following parameters are only required for the AdvancedMode. -->
-        <param name="grip_max_vacuum_pressure">-60</param>
-        <param name="grip_min_vacuum_pressure">-10</param>
-        <param name="grip_timeout">25.0</param>
-        <param name="release_timeout">2.0</param>
+        <param name="grip_max_vacuum_pressure">${grip_max_vacuum_pressure}</param>
+        <param name="grip_min_vacuum_pressure">${grip_min_vacuum_pressure}</param>
+        <param name="grip_timeout">${grip_timeout}</param>
+        <param name="release_timeout">${release_timeout}</param>
 
       </hardware>
 

--- a/epick_description/urdf/epick_driver_ros2_control.xacro
+++ b/epick_description/urdf/epick_driver_ros2_control.xacro
@@ -15,7 +15,7 @@
         <!-- Gripper parameters /////////////////////////////////////////// -->
 
         <!-- Set use_dummy to true to connect to a dummy driver for testing purposes. -->
-        <param name="use_dummy">false</param>
+        <param name="use_dummy">${use_fake_hardware}</param>
 
         <!-- The address of the gripper. -->
         <param name="slave_address">0x9</param>

--- a/epick_description/urdf/epick_single_suction_cup.xacro
+++ b/epick_description/urdf/epick_single_suction_cup.xacro
@@ -3,6 +3,7 @@
 
   <!-- Include EPick Body and helper macros -->
   <xacro:include filename="epick_body.xacro"/>
+  <xacro:include filename="$(find epick_description)/urdf/epick_driver_ros2_control.xacro" />
 
   <!-- Robotiq EPick + Suction Cup with optional extension
 
@@ -34,6 +35,9 @@
                        extension_radius:=0.0
                        extension_length:=0.0
                        tcp_stroke_compensation:=0.0">
+
+
+    <xacro:epick_driver_ros2_control name="epick_driver_ros2_control" />
 
     <!-- Body -->
     <!-- inherits prefix, parent and origin_*, exposes body_link, body_length, body_color -->
@@ -75,6 +79,5 @@
     <xacro:joint parent="${prefix}epick_tip"
                  child="${prefix}epick_tcp"
                  xyz="0 0 ${-tcp_stroke_compensation}"/>
-
   </xacro:macro>
 </robot>

--- a/epick_description/urdf/epick_single_suction_cup.xacro
+++ b/epick_description/urdf/epick_single_suction_cup.xacro
@@ -37,8 +37,8 @@
                        tcp_stroke_compensation:=0.0
                        use_fake_hardware:=true">
 
-    <xacro:epick_driver_ros2_control 
-      name="epick_driver_ros2_control" 
+    <xacro:epick_driver_ros2_control
+      name="epick_driver_ros2_control"
       use_fake_hardware="${use_fake_hardware}"/>
 
     <!-- Body -->

--- a/epick_description/urdf/epick_single_suction_cup.xacro
+++ b/epick_description/urdf/epick_single_suction_cup.xacro
@@ -34,10 +34,12 @@
                        suction_cup_height:=0.015
                        extension_radius:=0.0
                        extension_length:=0.0
-                       tcp_stroke_compensation:=0.0">
+                       tcp_stroke_compensation:=0.0
+                       use_fake_hardware:=true">
 
-
-    <xacro:epick_driver_ros2_control name="epick_driver_ros2_control" />
+    <xacro:epick_driver_ros2_control 
+      name="epick_driver_ros2_control" 
+      use_fake_hardware="${use_fake_hardware}"/>
 
     <!-- Body -->
     <!-- inherits prefix, parent and origin_*, exposes body_link, body_length, body_color -->

--- a/epick_description/urdf/epick_single_suction_cup.xacro
+++ b/epick_description/urdf/epick_single_suction_cup.xacro
@@ -35,11 +35,14 @@
                        extension_radius:=0.0
                        extension_length:=0.0
                        tcp_stroke_compensation:=0.0
-                       use_fake_hardware:=true">
+                       use_fake_hardware:=true
+                       usb_port:=/dev/ttyUSB0">
 
     <xacro:epick_driver_ros2_control
       name="epick_driver_ros2_control"
-      use_fake_hardware="${use_fake_hardware}"/>
+      use_fake_hardware="${use_fake_hardware}"
+      usb_port="${usb_port}"
+    />
 
     <!-- Body -->
     <!-- inherits prefix, parent and origin_*, exposes body_link, body_length, body_color -->

--- a/epick_description/urdf/epick_single_suction_cup.xacro
+++ b/epick_description/urdf/epick_single_suction_cup.xacro
@@ -79,5 +79,14 @@
     <xacro:joint parent="${prefix}epick_tip"
                  child="${prefix}epick_tcp"
                  xyz="0 0 ${-tcp_stroke_compensation}"/>
+
+    <!-- To allow MoveIt to actuate the gripper as part of a trajectory, we need to include a fake "joint" in the URDF corresponding to the Epick's vacuum state. -->
+    <link name="${prefix}epick_vacuum_state"/>
+    <joint name="gripper" type="revolute">
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <parent link="${prefix}epick_tcp"/>
+      <child link="${prefix}epick_vacuum_state"/>
+      <limit effort="30" velocity="1.0" lower="0.0" upper="1.0" />
+    </joint>
   </xacro:macro>
 </robot>

--- a/epick_description/urdf/example.urdf.xacro
+++ b/epick_description/urdf/example.urdf.xacro
@@ -1,11 +1,9 @@
 <?xml version="1.0"?>
 <robot name="example_robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:include filename="$(find epick_description)/urdf/epick_single_suction_cup.xacro" ns="robotiq"/>
-  <xacro:include filename="$(find epick_description)/urdf/epick_driver_ros2_control.xacro" />
+  <xacro:include filename="$(find epick_description)/urdf/epick_single_suction_cup.xacro"/>
 
   <link name="world"/>
-  <xacro:robotiq.epick_single_suction_cup parent="world"/>
-  <xacro:epick_driver_ros2_control name="epick_driver_ros2_control" />
+  <xacro:epick_single_suction_cup parent="world" use_fake_hardware="false"/>
 
 </robot>

--- a/epick_driver/src/default_driver_factory.cpp
+++ b/epick_driver/src/default_driver_factory.cpp
@@ -62,7 +62,7 @@ constexpr auto kReleaseTimeoutParamName = "release_timeout";
 constexpr auto kReleaseTimeoutParamDefault = 0.5;
 
 constexpr auto kUseDummyParamName = "use_dummy";
-constexpr auto kUseDummyParamDefault = "False";  // TODO: make this so it's not case sensitive
+constexpr auto kUseDummyParamDefault = "False";  // TODO(kineticsystem): make this so it's not case sensitive
 
 std::unique_ptr<epick_driver::Driver>
 epick_driver::DefaultDriverFactory::create(const hardware_interface::HardwareInfo& info) const

--- a/epick_driver/src/default_driver_factory.cpp
+++ b/epick_driver/src/default_driver_factory.cpp
@@ -62,7 +62,7 @@ constexpr auto kReleaseTimeoutParamName = "release_timeout";
 constexpr auto kReleaseTimeoutParamDefault = 0.5;
 
 constexpr auto kUseDummyParamName = "use_dummy";
-constexpr auto kUseDummyParamDefault = "false";
+constexpr auto kUseDummyParamDefault = "False"; // TODO: make this so it's not case sensitive
 
 std::unique_ptr<epick_driver::Driver>
 epick_driver::DefaultDriverFactory::create(const hardware_interface::HardwareInfo& info) const

--- a/epick_driver/src/default_driver_factory.cpp
+++ b/epick_driver/src/default_driver_factory.cpp
@@ -62,7 +62,7 @@ constexpr auto kReleaseTimeoutParamName = "release_timeout";
 constexpr auto kReleaseTimeoutParamDefault = 0.5;
 
 constexpr auto kUseDummyParamName = "use_dummy";
-constexpr auto kUseDummyParamDefault = "False"; // TODO: make this so it's not case sensitive
+constexpr auto kUseDummyParamDefault = "False";  // TODO: make this so it's not case sensitive
 
 std::unique_ptr<epick_driver::Driver>
 epick_driver::DefaultDriverFactory::create(const hardware_interface::HardwareInfo& info) const

--- a/epick_moveit_plugin/CMakeLists.txt
+++ b/epick_moveit_plugin/CMakeLists.txt
@@ -1,0 +1,40 @@
+# See https://docs.ros.org/en/foxy/How-To-Guides/Ament-CMake-Documentation.html
+
+cmake_minimum_required(VERSION 3.8)
+project(epick_moveit_plugin VERSION 0.0.1 LANGUAGES CXX)
+
+# This module provides installation directories as per the GNU coding standards.
+include(GNUInstallDirs)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS true)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(moveit_ros_control_interface REQUIRED)
+find_package(moveit_simple_controller_manager REQUIRED)
+find_package(pluginlib REQUIRED)
+
+add_library(epick_gripper_controller_allocator SHARED
+  src/epick_gripper_controller_allocator.cpp
+)
+ament_target_dependencies(epick_gripper_controller_allocator PUBLIC
+  pluginlib
+  moveit_ros_control_interface
+  moveit_simple_controller_manager
+)
+
+pluginlib_export_plugin_description_file(moveit_ros_control_interface moveit_ros_control_interface_plugins.xml)
+
+# Install our library.
+install(
+  TARGETS epick_gripper_controller_allocator
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}      # lib
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}      # lib
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}      # bin
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} # include
+)
+
+ament_package()

--- a/epick_moveit_plugin/CMakeLists.txt
+++ b/epick_moveit_plugin/CMakeLists.txt
@@ -26,6 +26,7 @@ ament_target_dependencies(epick_gripper_controller_allocator PUBLIC
   moveit_simple_controller_manager
 )
 
+# Register the Epick gripper controller allocator plugin with MoveIt's ros_control interface
 pluginlib_export_plugin_description_file(moveit_ros_control_interface moveit_ros_control_interface_plugins.xml)
 
 # Install our library.

--- a/epick_moveit_plugin/moveit_ros_control_interface_plugins.xml
+++ b/epick_moveit_plugin/moveit_ros_control_interface_plugins.xml
@@ -1,4 +1,6 @@
 <library path="epick_gripper_controller_allocator">
+    <!-- The name defined here must match the name of the controller plugin as defined in epick_controllers/controller_plugins.xml.
+         This is how we tell MoveIt's controller manager to load this controller allocator for this specific type of controller. -->
     <class name="epick_controllers/EpickGripperActionController" type="epick_moveit_plugin::EpickGripperControllerAllocator" base_class_type="moveit_ros_control_interface::ControllerHandleAllocator">
         <description></description>
     </class>

--- a/epick_moveit_plugin/moveit_ros_control_interface_plugins.xml
+++ b/epick_moveit_plugin/moveit_ros_control_interface_plugins.xml
@@ -1,0 +1,5 @@
+<library path="epick_gripper_controller_allocator">
+    <class name="epick_controllers/EpickGripperActionController" type="epick_moveit_plugin::EpickGripperControllerAllocator" base_class_type="moveit_ros_control_interface::ControllerHandleAllocator">
+        <description></description>
+    </class>
+</library>

--- a/epick_moveit_plugin/package.xml
+++ b/epick_moveit_plugin/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>epick_moveit_plugin</name>
+  <version>0.0.1</version>
+  <description>Controllers for the Robotiq Epick gripper.</description>
+  <maintainer email="giovanni.remigi@picknik.ai">Giovanni Remigi</maintainer>
+  <license>BSD-3-Clause</license>
+  <author>Giovanni Remigi</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>moveit_ros_control_interface</depend>
+  <depend>moveit_simple_controller_manager</depend>
+  <depend>pluginlib</depend>
+
+  <exec_depend>epick_controllers</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/epick_moveit_plugin/src/epick_gripper_controller_allocator.cpp
+++ b/epick_moveit_plugin/src/epick_gripper_controller_allocator.cpp
@@ -1,0 +1,66 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Fraunhofer IPA nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <moveit_ros_control_interface/ControllerHandle.h>
+#include <pluginlib/class_list_macros.hpp>
+#include <moveit_simple_controller_manager/gripper_controller_handle.h>
+#include <rclcpp/node.hpp>
+#include <memory>
+
+namespace
+{
+constexpr auto kGripperCommandAction = "gripper_cmd";
+}  // namespace
+
+namespace epick_moveit_plugin
+{
+/**
+ * \brief Controller allocator plugin to allow the EpickGripperActionController to be
+ */
+class EpickGripperControllerAllocator : public moveit_ros_control_interface::ControllerHandleAllocator
+{
+public:
+  moveit_controller_manager::MoveItControllerHandlePtr alloc(const rclcpp::Node::SharedPtr& node,
+                                                             const std::string& name,
+                                                             const std::vector<std::string>& /* resources */) override
+  {
+    return std::make_shared<moveit_simple_controller_manager::GripperControllerHandle>(node, name,
+                                                                                       kGripperCommandAction);
+  }
+};
+
+}  // namespace epick_moveit_plugin
+
+PLUGINLIB_EXPORT_CLASS(epick_moveit_plugin::EpickGripperControllerAllocator,
+                       moveit_ros_control_interface::ControllerHandleAllocator);

--- a/epick_moveit_plugin/src/epick_gripper_controller_allocator.cpp
+++ b/epick_moveit_plugin/src/epick_gripper_controller_allocator.cpp
@@ -46,7 +46,7 @@ constexpr auto kGripperCommandAction = "gripper_cmd";
 namespace epick_moveit_plugin
 {
 /**
- * \brief Controller allocator plugin to allow the EpickGripperActionController to be
+ * \brief Controller allocator plugin to allow the EpickGripperActionController to execute trajectories using MoveIt in the same way as the ros2_controllers GripperActionController
  */
 class EpickGripperControllerAllocator : public moveit_ros_control_interface::ControllerHandleAllocator
 {

--- a/epick_moveit_plugin/src/epick_gripper_controller_allocator.cpp
+++ b/epick_moveit_plugin/src/epick_gripper_controller_allocator.cpp
@@ -46,7 +46,8 @@ constexpr auto kGripperCommandAction = "gripper_cmd";
 namespace epick_moveit_plugin
 {
 /**
- * \brief Controller allocator plugin to allow the EpickGripperActionController to execute trajectories using MoveIt in the same way as the ros2_controllers GripperActionController
+ * \brief Controller allocator plugin to allow the EpickGripperActionController to execute trajectories using MoveIt in
+ * the same way as the ros2_controllers GripperActionController
  */
 class EpickGripperControllerAllocator : public moveit_ros_control_interface::ControllerHandleAllocator
 {


### PR DESCRIPTION
- Add an EpickGripperActionController based on the ros2_controllers GripperActionController. This connects the gripper hardware interface's `regulate` command interface to an action server.
- Add a new EpickStatusPublisherController. This reads the gripper's state interfaces and publishes them to a topic.