### PR TITLE
Added test library

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,10 @@
+[flake8]
+max-line-length = 88
+
+# Report all errors starting with E, F, W or C - or Bugbear's B590 rule, which is a "pragmatic" version of E501 (line too long)
+select = E,F,W,C,B590
+
+# Ignore W503 - Line break occurred before a binary operator - because this error is introduced by Black formatter.
+# Ignore E203 - whitespace before ':' - because Black includes spaces in formatting slice expressions.
+# Ignore E501 - line too long - in favor of B590, which is more forgiving of long strings and comments that would be silly to break up.
+extend-ignore = W503, E203, E501

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@
 repos:
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-added-large-files
         exclude: \.(stl|dae)$
@@ -32,18 +32,25 @@ repos:
       - id: fix-byte-order-marker
 
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 23.3.0
     hooks:
       - id: black
 
+  - repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
+    hooks:
+    - id: flake8
+      # configured in .flake8 file
+
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
+    rev: v2.2.5
     hooks:
       - id: codespell
         args: ['--write-changes', '-L', 'atleast']  # Provide a comma-separated list of misspelled words that codespell should ignore (for example: '-L', 'word1,word2,word3').
         exclude: \.(svg|pyc|stl|dae|lock)$
 
-  - repo: local
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v16.0.6
     hooks:
       - id: clang-format
         name: clang-format

--- a/epick_driver/tests/CMakeLists.txt
+++ b/epick_driver/tests/CMakeLists.txt
@@ -33,6 +33,9 @@ target_include_directories(test_epick_gripper_hardware_interface
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
 )
 target_link_libraries(test_epick_gripper_hardware_interface epick_driver)
+ament_target_dependencies(test_epick_gripper_hardware_interface
+    ros2_control_test_assets
+)
 
 ###############################################################################
 # test_default_serial_factory

--- a/epick_hardware_tests/CMakeLists.txt
+++ b/epick_hardware_tests/CMakeLists.txt
@@ -31,9 +31,6 @@ add_executable(activate
     src/command_line_utility.hpp
     src/command_line_utility.cpp
 )
-target_include_directories(activate
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(activate epick_driver::epick_driver)
 ament_target_dependencies(activate epick_driver)
 
 add_executable(deactivate
@@ -41,9 +38,6 @@ add_executable(deactivate
     src/command_line_utility.hpp
     src/command_line_utility.cpp
 )
-target_include_directories(deactivate
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(deactivate epick_driver::epick_driver)
 ament_target_dependencies(deactivate epick_driver)
 
 add_executable(get_status
@@ -51,9 +45,6 @@ add_executable(get_status
     src/command_line_utility.hpp
     src/command_line_utility.cpp
 )
-target_include_directories(get_status
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(get_status epick_driver::epick_driver)
 ament_target_dependencies(get_status epick_driver)
 
 add_executable(grip
@@ -61,9 +52,6 @@ add_executable(grip
     src/command_line_utility.hpp
     src/command_line_utility.cpp
 )
-target_include_directories(grip
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(grip epick_driver::epick_driver)
 ament_target_dependencies(grip epick_driver)
 
 add_executable(release
@@ -71,9 +59,6 @@ add_executable(release
     src/command_line_utility.hpp
     src/command_line_utility.cpp
 )
-target_include_directories(release
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(release epick_driver::epick_driver)
 ament_target_dependencies(release epick_driver)
 
 add_executable(break
@@ -81,9 +66,6 @@ add_executable(break
     src/command_line_utility.hpp
     src/command_line_utility.cpp
 )
-target_include_directories(break
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(break epick_driver::epick_driver)
 ament_target_dependencies(break epick_driver)
 
 ament_package()


### PR DESCRIPTION
I added the following missing library to the `test_epick_gripper_hardware_interface`

```
ament_target_dependencies(test_epick_gripper_hardware_interface
    ros2_control_test_assets
)
```

This is not required for Humble, but it is definitely required for Iron and Rolling.