### PR TITLE
Added "gripper/position" joint state interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Format](https://github.com/PickNikRobotics/ros2_epick_gripper/actions/workflows/ci-format.yml/badge.svg)](https://github.com/PickNikRobotics/ros2_epick_gripper/actions/workflows/ci-format.yml)
 [![Linters](https://github.com/PickNikRobotics/ros2_epick_gripper/actions/workflows/ci-ros-lint.yml/badge.svg)](https://github.com/PickNikRobotics/ros2_epick_gripper/actions/workflows/ci-ros-lint.yml)
 
-
 This repository contains the ROS 2 driver, controller, and description packages for working with a Robotiq EPick Gripper.
 
 ## Hardware Interface
@@ -71,6 +70,20 @@ Below is a sample configuration that outlines various parameters for this interf
         -->
         <state_interface name="object_detection_status"/>
       </gpio>
+
+      <!--
+        This is optional configuration if you want to publish the state of the
+        gripper as a joint state interface.
+      -->
+      <joint name="gripper">
+        <!--
+          State interface that follows the value of the gripper/grip_cmd
+          command interface:
+          1.0 = successful grip
+          0.0 = successful release
+        -->
+        <state_interface name="position"/>
+      </joint>
 
     </ros2_control>
 

--- a/epick_description/urdf/epick_driver_ros2_control.xacro
+++ b/epick_description/urdf/epick_driver_ros2_control.xacro
@@ -40,7 +40,8 @@
         <command_interface name="grip_cmd"/>
 
         <!--
-          State interface that follow the value of the command interface:
+          State interface that follows the value of the gripper/grip_cmd
+          command interface:
           1.0 = successful grip
           0.0 = successful release
         -->
@@ -55,6 +56,20 @@
         -->
         <state_interface name="object_detection_status"/>
       </gpio>
+
+      <!--
+        This is optional configuration if you want to publish the state of the
+        gripper as a joint state interface.
+      -->
+      <joint name="gripper">
+        <!--
+          State interface that follows the value of the gripper/grip_cmd
+          command interface:
+          1.0 = successful grip
+          0.0 = successful release
+        -->
+        <state_interface name="position"/>
+      </joint>
 
     </ros2_control>
 

--- a/epick_driver/include/epick_driver/hardware_interface_utils.hpp
+++ b/epick_driver/include/epick_driver/hardware_interface_utils.hpp
@@ -56,6 +56,26 @@ get_gpios_state_interface(std::string gpio_name, std::string interface_name,
                           const hardware_interface::HardwareInfo& info);
 
 /**
+ * Look for a joint command interface in the hardware info.
+ * @param joint_name The component name.
+ * @param interface_name The interface name.
+ * @return the interface info of the requested interface, if any.
+ */
+std::optional<hardware_interface::InterfaceInfo>
+get_joints_command_interface(std::string joint_name, std::string interface_name,
+                             const hardware_interface::HardwareInfo& info);
+
+/**
+ * Look for a joint state interface in the hardware info.
+ * @param joint_name The component name.
+ * @param interface_name The interface name.
+ * @return the interface info of the requested interface, if any.
+ */
+std::optional<hardware_interface::InterfaceInfo>
+get_joints_state_interface(std::string joint_name, std::string interface_name,
+                           const hardware_interface::HardwareInfo& info);
+
+/**
  * All command and state interfaces work with double values. We can
  * use double value to represent boolean values:
  * 0.0 = true

--- a/epick_driver/src/data_utils.cpp
+++ b/epick_driver/src/data_utils.cpp
@@ -78,7 +78,7 @@ std::string to_hex(const std::vector<uint16_t>& bytes)
 
 std::string to_binary_string(const uint8_t byte)
 {
-  std::string result = "0x";
+  std::string result = "";
   for (int i = 7; i >= 0; --i)
   {
     result += ((byte >> i) & 1) ? '1' : '0';

--- a/epick_driver/src/epick_gripper_hardware_interface.cpp
+++ b/epick_driver/src/epick_gripper_hardware_interface.cpp
@@ -45,17 +45,18 @@ namespace epick_driver
 {
 const auto kLogger = rclcpp::get_logger("EpickGripperHardwareInterface");
 
-constexpr auto kGripperGPIO = "gripper";
+constexpr auto kGripperPrefixName = "gripper";
 
-constexpr auto kGripCommandInterface = "grip_cmd";
+constexpr auto kGripCommandInterfaceName = "grip_cmd";
+constexpr auto kGripStateInterfacename = "grip_cmd";
 
-constexpr auto kGripStateInterface = "grip_cmd";
-constexpr auto kObjectDetectionStateInterface = "object_detection_status";
+constexpr auto kObjectDetectionStateInterfaceName = "object_detection_status";
 
 constexpr auto kGripperCommsLoopPeriod = std::chrono::milliseconds{ 10 };
 
 using epick_driver::hardware_interface_utils::get_gpios_command_interface;
 using epick_driver::hardware_interface_utils::get_gpios_state_interface;
+using epick_driver::hardware_interface_utils::get_joints_state_interface;
 using epick_driver::hardware_interface_utils::is_false;
 using epick_driver::hardware_interface_utils::is_true;
 
@@ -141,23 +142,30 @@ std::vector<hardware_interface::StateInterface> EpickGripperHardwareInterface::e
   std::vector<hardware_interface::StateInterface> state_interfaces;
   try
   {
-    if (get_gpios_state_interface(kGripperGPIO, kObjectDetectionStateInterface, info_).has_value())
+    if (get_gpios_state_interface(kGripperPrefixName, kObjectDetectionStateInterfaceName, info_).has_value())
     {
-      state_interfaces.emplace_back(hardware_interface::StateInterface(kGripperGPIO, kObjectDetectionStateInterface,
-                                                                       &gripper_status_.object_detection_status));
+      state_interfaces.emplace_back(hardware_interface::StateInterface(
+          kGripperPrefixName, kObjectDetectionStateInterfaceName, &gripper_status_.object_detection_status));
     }
     else
     {
-      RCLCPP_ERROR(kLogger, "State interface %s/%s not found.", kGripperGPIO, kObjectDetectionStateInterface);
+      RCLCPP_ERROR(kLogger, "State interface %s/%s not found.", kGripperPrefixName, kObjectDetectionStateInterfaceName);
     }
-    if (get_gpios_state_interface(kGripperGPIO, kGripStateInterface, info_).has_value())
+    if (get_gpios_state_interface(kGripperPrefixName, kGripStateInterfacename, info_).has_value())
     {
       state_interfaces.emplace_back(
-          hardware_interface::StateInterface(kGripperGPIO, kGripStateInterface, &gripper_status_.grip_cmd));
+          hardware_interface::StateInterface(kGripperPrefixName, kGripStateInterfacename, &gripper_status_.grip_cmd));
     }
     else
     {
-      RCLCPP_ERROR(kLogger, "State interface %s/%s not found.", kGripperGPIO, kGripStateInterface);
+      RCLCPP_ERROR(kLogger, "State interface %s/%s not found.", kGripperPrefixName, hardware_interface::HW_IF_POSITION);
+    }
+
+    // This joint state is optional.
+    if (get_joints_state_interface(kGripperPrefixName, hardware_interface::HW_IF_POSITION, info_).has_value())
+    {
+      state_interfaces.emplace_back(hardware_interface::StateInterface(
+          kGripperPrefixName, hardware_interface::HW_IF_POSITION, &gripper_status_.grip_cmd));
     }
   }
   catch (const std::exception& ex)
@@ -175,14 +183,14 @@ std::vector<hardware_interface::CommandInterface> EpickGripperHardwareInterface:
   std::vector<hardware_interface::CommandInterface> command_interfaces;
   try
   {
-    if (get_gpios_command_interface(kGripperGPIO, kGripCommandInterface, info_).has_value())
+    if (get_gpios_command_interface(kGripperPrefixName, kGripCommandInterfaceName, info_).has_value())
     {
       command_interfaces.emplace_back(
-          hardware_interface::CommandInterface(kGripperGPIO, kGripCommandInterface, &gripper_cmds_.grip_cmd));
+          hardware_interface::CommandInterface(kGripperPrefixName, kGripCommandInterfaceName, &gripper_cmds_.grip_cmd));
     }
     else
     {
-      RCLCPP_ERROR(kLogger, "Command interface %s/%s not found.", kGripperGPIO, kGripCommandInterface);
+      RCLCPP_ERROR(kLogger, "Command interface %s/%s not found.", kGripperPrefixName, kGripCommandInterfaceName);
     }
   }
   catch (const std::exception& ex)

--- a/epick_driver/src/hardware_interface_utils.cpp
+++ b/epick_driver/src/hardware_interface_utils.cpp
@@ -89,4 +89,46 @@ bool is_false(double value)
   return value < 0.5;
 }
 
+std::optional<hardware_interface::InterfaceInfo>
+get_joints_command_interface(std::string joint_name, std::string interface_name,
+                             const hardware_interface::HardwareInfo& info)
+{
+  auto joint_component = std::find_if(info.joints.begin(), info.joints.end(),
+                                      [&joint_name](const auto& gpio) { return gpio.name == joint_name; });
+
+  if (joint_component != info.joints.end())
+  {
+    auto hardware_info =
+        std::find_if(joint_component->command_interfaces.begin(), joint_component->command_interfaces.end(),
+                     [&interface_name](const auto& cmd) { return cmd.name == interface_name; });
+
+    if (hardware_info != joint_component->command_interfaces.end())
+    {
+      return *hardware_info;
+    }
+  }
+  return std::nullopt;
+}
+
+std::optional<hardware_interface::InterfaceInfo>
+get_joints_state_interface(std::string joint_name, std::string interface_name,
+                           const hardware_interface::HardwareInfo& info)
+{
+  auto joint_component = std::find_if(info.joints.begin(), info.joints.end(),
+                                      [&joint_name](const auto& gpio) { return gpio.name == joint_name; });
+
+  if (joint_component != info.joints.end())
+  {
+    auto hardware_info =
+        std::find_if(joint_component->state_interfaces.begin(), joint_component->state_interfaces.end(),
+                     [&interface_name](const auto& cmd) { return cmd.name == interface_name; });
+
+    if (hardware_info != joint_component->state_interfaces.end())
+    {
+      return *hardware_info;
+    }
+  }
+  return std::nullopt;
+}
+
 }  // namespace epick_driver::hardware_interface_utils


### PR DESCRIPTION
In this PR we added an optional "gripper/position" joint state interface which is an alias for the "gripper/gripper_cmd" GPIO state interface.

We added this joint state interface so we can control the gripper using our existing MTC behaviors.