### PR TITLE
Converting a WARNING message into a DEBUG message.

### DIFF
--- a/epick_driver/src/default_driver.cpp
+++ b/epick_driver/src/default_driver.cpp
@@ -120,8 +120,8 @@ std::vector<uint8_t> DefaultDriver::send(const std::vector<uint8_t>& request, si
     }
     catch (const serial::IOException& e)
     {
-      RCLCPP_WARN(kLogger, "Resending the command because the previous attempt (%d of %d) failed: %s", retry_count + 1,
-                  kMaxRetries, e.what());
+      RCLCPP_DEBUG(kLogger, "Resending the command because the previous attempt (%d of %d) failed: %s", retry_count + 1,
+                   kMaxRetries, e.what());
       retry_count++;
     }
   }


### PR DESCRIPTION
When the gripper does not return a response we raise a warning even if we can correct it by sending a second message.

For these reason I converted the WARNING into a DEBUG.