### PR TITLE
Fix comparison of command and state in EpickGripperActionController success check

### DIFF
--- a/epick_controllers/src/epick_gripper_action_controller.cpp
+++ b/epick_controllers/src/epick_gripper_action_controller.cpp
@@ -41,7 +41,7 @@ namespace
 /**
  * @brief Convert a double to a bool using the same logic the EpickGripperHardwareInterface uses to convert
  * the boolean gripper command and state values into doubles when storing them in the ros2_control interfaces.
- * 
+ *
  * @param value Value to convert
  * @return Returns true if the value is greater than or equal to 0.5, and false if it is less than 0.5.
  */
@@ -49,7 +49,7 @@ bool toBool(double value)
 {
   return value >= 0.5;
 }
-}
+}  // namespace
 
 namespace epick_controllers
 {

--- a/epick_controllers/src/epick_gripper_action_controller.cpp
+++ b/epick_controllers/src/epick_gripper_action_controller.cpp
@@ -36,6 +36,21 @@
 #include <hardware_interface/loaned_command_interface.hpp>
 #include <hardware_interface/loaned_state_interface.hpp>
 
+namespace
+{
+/**
+ * @brief Convert a double to a bool using the same logic the EpickGripperHardwareInterface uses to convert
+ * the boolean gripper command and state values into doubles when storing them in the ros2_control interfaces.
+ * 
+ * @param value Value to convert
+ * @return Returns true if the value is greater than or equal to 0.5, and false if it is less than 0.5.
+ */
+bool toBool(double value)
+{
+  return value >= 0.5;
+}
+}
+
 namespace epick_controllers
 {
 constexpr auto kGripCommandInterface = "gripper/grip_cmd";
@@ -212,7 +227,8 @@ void EpickGripperActionController::check_for_success(const double current_regula
     return;
   }
 
-  if (std::abs(current_regulate_command - current_regulate_state) < std::numeric_limits<double>::epsilon())
+  // The action has succeeded if the gripper's state becomes equal to the commanded value.
+  if (toBool(current_regulate_command) == toBool(current_regulate_state))
   {
     RCLCPP_INFO(get_node()->get_logger(), "success!");
 


### PR DESCRIPTION
The gripper command and gripper state interface values represent boolean values (since the Epick vacuum pump is either on or off), but due to limitations in ros2_control they are stored as doubles. This can result in some problems with floating-point precision where the command and state values are equivalent but not equal, which sometimes prevents the gripper action controller from successfully determining that the gripper has reached the commanded state.

This fixes that issue by converting the double values into boolean values before comparing them, using the same logic as is used in the EpickGripperHardwareInterface.