### PR TITLE
Revert clang-format mirror to v14.0.6 to let it run successfully

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,12 +50,9 @@ repos:
         exclude: \.(svg|pyc|stl|dae|lock)$
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v16.0.6
+    rev: v14.0.6
     hooks:
       - id: clang-format
-        name: clang-format
-        description: Format files with ClangFormat.
-        entry: clang-format-14
-        language: system
         files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|m|proto|vert)$
-        args: ['-fallback-style=none', '-i']
+        # -i arg is included by default by the hook
+        args: ["-fallback-style=none"]


### PR DESCRIPTION
I was encountering an error running pre-commit on my system using the current config. To let it run successfully I had to downgrade the version we target in .pre-commit-config.yaml. I also simplified the options we pass when configuring it, since the defaults are sufficient for our needs.