### PR TITLE
Add MoveIt Studio behaviors to monitor Epick vacuum state

### DIFF
--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -10,6 +10,8 @@ jobs:
           - { ROS_DISTRO: humble, ROS_REPO: testing }
           - { ROS_DISTRO: humble, ROS_REPO: main }
     env:
+      # Remove the epick_moveit_studio package from the workspace before running CI, since its dependencies are not available in CI for this repo.
+      TARGET_WORKSPACE: '. -epick_moveit_studio'
       UPSTREAM_WORKSPACE: ros2_robotiq_gripper.humble.repos
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
     rev: v2.2.5
     hooks:
       - id: codespell
-        args: ['--write-changes', '-L', 'atleast', 'inout']  # Provide a comma-separated list of misspelled words that codespell should ignore (for example: '-L', 'word1,word2,word3').
+        args: ['--write-changes', '-L', 'atleast,inout']  # Provide a comma-separated list of misspelled words that codespell should ignore (for example: '-L', 'word1,word2,word3').
         exclude: \.(svg|pyc|stl|dae|lock)$
 
   - repo: https://github.com/pre-commit/mirrors-clang-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
     rev: v2.2.5
     hooks:
       - id: codespell
-        args: ['--write-changes', '-L', 'atleast']  # Provide a comma-separated list of misspelled words that codespell should ignore (for example: '-L', 'word1,word2,word3').
+        args: ['--write-changes', '-L', 'atleast', 'inout']  # Provide a comma-separated list of misspelled words that codespell should ignore (for example: '-L', 'word1,word2,word3').
         exclude: \.(svg|pyc|stl|dae|lock)$
 
   - repo: https://github.com/pre-commit/mirrors-clang-format

--- a/epick_moveit_studio/CMakeLists.txt
+++ b/epick_moveit_studio/CMakeLists.txt
@@ -1,0 +1,57 @@
+cmake_minimum_required(VERSION 3.8)
+project(epick_moveit_studio LANGUAGES CXX)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS true)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(epick_msgs REQUIRED)
+find_package(moveit_studio_behavior_interface REQUIRED)
+find_package(pluginlib REQUIRED)
+
+add_library(epick_behaviors SHARED
+  src/get_epick_object_detection_status.cpp
+  src/behavior_loader.cpp
+)
+target_include_directories(epick_behaviors
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  PUBLIC $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(epick_behaviors PUBLIC moveit_studio_behavior_interface::shared_resources_node moveit_studio_behavior_interface::get_message_from_topic)
+ament_target_dependencies(epick_behaviors PUBLIC
+  epick_msgs
+  moveit_studio_behavior_interface
+  pluginlib
+)
+
+install(
+  TARGETS
+    epick_behaviors
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)
+
+install(
+  DIRECTORY
+    config
+  DESTINATION share/${PROJECT_NAME}
+)
+
+
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()
+
+pluginlib_export_plugin_description_file(moveit_studio_behavior_interface behavior_plugin_description.xml)
+
+ament_export_include_directories(include)
+ament_export_libraries(epick_behaviors)
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_dependencies(epick_msgs moveit_studio_behavior_interface pluginlib)
+ament_package()

--- a/epick_moveit_studio/CMakeLists.txt
+++ b/epick_moveit_studio/CMakeLists.txt
@@ -21,7 +21,7 @@ target_include_directories(epick_behaviors
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PUBLIC $<INSTALL_INTERFACE:include>
 )
-target_link_libraries(epick_behaviors PUBLIC moveit_studio_behavior_interface::shared_resources_node moveit_studio_behavior_interface::get_message_from_topic)
+target_link_libraries(epick_behaviors PUBLIC moveit_studio_behavior_interface::async_behavior_base)
 ament_target_dependencies(epick_behaviors PUBLIC
   epick_msgs
   moveit_studio_behavior_interface

--- a/epick_moveit_studio/CMakeLists.txt
+++ b/epick_moveit_studio/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(moveit_studio_behavior_interface REQUIRED)
 find_package(pluginlib REQUIRED)
 
 add_library(epick_behaviors SHARED
+  src/compare_epick_object_detection_status.cpp
   src/get_epick_object_detection_status.cpp
   src/behavior_loader.cpp
 )

--- a/epick_moveit_studio/behavior_plugin_description.xml
+++ b/epick_moveit_studio/behavior_plugin_description.xml
@@ -1,0 +1,5 @@
+<library path="epick_behaviors">
+  <class type="epick_moveit_studio::BehaviorLoader"
+         base_class_type="moveit_studio::behaviors::SharedResourcesNodeLoaderBase">
+  </class>
+</library>

--- a/epick_moveit_studio/config/tree_nodes_model.xml
+++ b/epick_moveit_studio/config/tree_nodes_model.xml
@@ -1,5 +1,17 @@
 <root>
     <TreeNodesModel>
+        <Action ID="CompareEpickObjectDetectionStatus">
+            <metadata subcategory="Robotiq Epick Gripper"/>
+            <description>
+                <p>
+                    Compare two ObjectDetectionStatus messages.
+                </p>
+            </description>
+            <input_port name="value1" default="">First ObjectDetectionStatus message to compare.</input_port>
+            <input_port name="value2" default="">Second ObjectDetectionStatus message to compare.</input_port>
+        </Action>
+    </TreeNodesModel>
+    <TreeNodesModel>
         <Action ID="GetEpickObjectDetectionStatus">
             <metadata subcategory="Robotiq Epick Gripper"/>
             <description>

--- a/epick_moveit_studio/config/tree_nodes_model.xml
+++ b/epick_moveit_studio/config/tree_nodes_model.xml
@@ -1,0 +1,14 @@
+<root>
+    <TreeNodesModel>
+        <Action ID="GetEpickObjectDetectionStatus">
+            <metadata subcategory="Robotiq Epick Gripper"/>
+            <description>
+                <p>
+                    Captures an ObjectDetectionStatus message and makes it available on an output port.
+                </p>
+            </description>
+            <input_port name="topic_name" default="">ObjectDetectionStatus topic the behavior subscribes to.</input_port>
+            <output_port name="message_out" default="{point_cloud}">Contains the message that was received on the topic.</output_port>
+        </Action>
+    </TreeNodesModel>
+</root>

--- a/epick_moveit_studio/config/tree_nodes_model.xml
+++ b/epick_moveit_studio/config/tree_nodes_model.xml
@@ -1,7 +1,7 @@
 <root>
     <TreeNodesModel>
         <Action ID="CompareEpickObjectDetectionStatus">
-            <metadata subcategory="Robotiq Epick Gripper"/>
+            <metadata subcategory="Robotiq EPick Gripper"/>
             <description>
                 <p>
                     Compare two ObjectDetectionStatus messages.
@@ -13,7 +13,7 @@
     </TreeNodesModel>
     <TreeNodesModel>
         <Action ID="GetEpickObjectDetectionStatus">
-            <metadata subcategory="Robotiq Epick Gripper"/>
+            <metadata subcategory="Robotiq EPick Gripper"/>
             <description>
                 <p>
                     Captures an ObjectDetectionStatus message and makes it available on an output port.

--- a/epick_moveit_studio/config/tree_nodes_model.xml
+++ b/epick_moveit_studio/config/tree_nodes_model.xml
@@ -7,8 +7,8 @@
                     Compare two ObjectDetectionStatus messages.
                 </p>
             </description>
-            <input_port name="value1" default="">First ObjectDetectionStatus message to compare.</input_port>
-            <input_port name="value2" default="">Second ObjectDetectionStatus message to compare.</input_port>
+            <input_port name="value1" default="{status}">First ObjectDetectionStatus message to compare.</input_port>
+            <input_port name="value2" default="OBJECT_DETECTED_AT_MAX_PRESSURE">Second ObjectDetectionStatus message to compare.</input_port>
         </Action>
     </TreeNodesModel>
     <TreeNodesModel>
@@ -19,8 +19,8 @@
                     Captures an ObjectDetectionStatus message and makes it available on an output port.
                 </p>
             </description>
-            <input_port name="topic_name" default="">ObjectDetectionStatus topic the behavior subscribes to.</input_port>
-            <output_port name="message_out" default="{point_cloud}">Contains the message that was received on the topic.</output_port>
+            <input_port name="topic_name" default="/object_detection_status">ObjectDetectionStatus topic the behavior subscribes to.</input_port>
+            <output_port name="message_out" default="{status}">Contains the message that was received on the topic.</output_port>
         </Action>
     </TreeNodesModel>
 </root>

--- a/epick_moveit_studio/include/epick_moveit_studio/compare_epick_object_detection_status.hpp
+++ b/epick_moveit_studio/include/epick_moveit_studio/compare_epick_object_detection_status.hpp
@@ -29,6 +29,42 @@
 #pragma once
 
 #include <behaviortree_cpp/action_node.h>
+#include <behaviortree_cpp/exceptions.h>
+#include <epick_msgs/msg/object_detection_status.hpp>
+
+namespace BT
+{
+/**
+ * @brief Template specialization of convertToString to split a string into an epick_msgs::msg::ObjectDetectionStatus.
+ * @param str Input string to convert.
+ * @return epick_msgs::msg::ObjectDetectionStatus
+ */
+template <>
+inline epick_msgs::msg::ObjectDetectionStatus convertFromString<epick_msgs::msg::ObjectDetectionStatus>(BT::StringView str)
+{
+  using Status = epick_msgs::msg::ObjectDetectionStatus;
+  if (str == "OBJECT_DETECTED_AT_MIN_PRESSURE")
+  {
+    return epick_msgs::build<Status>().status(Status::OBJECT_DETECTED_AT_MIN_PRESSURE);
+  }
+  else if (str == "OBJECT_DETECTED_AT_MAX_PRESSURE")
+  {
+    return epick_msgs::build<Status>().status(Status::OBJECT_DETECTED_AT_MAX_PRESSURE);
+  }
+  else if (str == "NO_OBJECT_DETECTED")
+  {
+    return epick_msgs::build<Status>().status(Status::NO_OBJECT_DETECTED);
+  }
+  else if (str == "UNKNOWN")
+  {
+    return epick_msgs::build<Status>().status(Status::UNKNOWN);
+  }
+  else
+  {
+    throw BT::RuntimeError(std::string("Invalid input: ").append(str));
+  }
+}
+}  // namespace BT
 
 namespace epick_moveit_studio
 {

--- a/epick_moveit_studio/include/epick_moveit_studio/compare_epick_object_detection_status.hpp
+++ b/epick_moveit_studio/include/epick_moveit_studio/compare_epick_object_detection_status.hpp
@@ -35,12 +35,14 @@
 namespace BT
 {
 /**
- * @brief Template specialization of convertToString to split a string into an epick_msgs::msg::ObjectDetectionStatus.
+ * @brief Template specialization of convertToString to parse a string as an epick_msgs::msg::ObjectDetectionStatus.
+ * @details This allows setting one of the input ports of CompareEpickObjectDetectionStatus by typing a string.
  * @param str Input string to convert.
  * @return epick_msgs::msg::ObjectDetectionStatus
  */
 template <>
-inline epick_msgs::msg::ObjectDetectionStatus convertFromString<epick_msgs::msg::ObjectDetectionStatus>(BT::StringView str)
+inline epick_msgs::msg::ObjectDetectionStatus
+convertFromString<epick_msgs::msg::ObjectDetectionStatus>(BT::StringView str)
 {
   using Status = epick_msgs::msg::ObjectDetectionStatus;
   if (str == "OBJECT_DETECTED_AT_MIN_PRESSURE")
@@ -61,13 +63,26 @@ inline epick_msgs::msg::ObjectDetectionStatus convertFromString<epick_msgs::msg:
   }
   else
   {
-    throw BT::RuntimeError(std::string("Invalid input: ").append(str));
+    throw BT::RuntimeError(std::string("To convert into a ObjectDetectionStatus message, the input string must be one "
+                                       "of [OBJECT_DETECTED_AT_MIN_PRESSURE, OBJECT_DETECTED_AT_MAX_PRESSURE, "
+                                       "NO_OBJECT_DETECTED, UNKNOWN]. Cannot parse the provided string: ")
+                               .append(str));
   }
 }
 }  // namespace BT
 
 namespace epick_moveit_studio
 {
+/**
+ * @brief Behavior to compare ObjectDetectionStatus messages.
+ * @details When ticked, gets two epick_msgs::msg::ObjectDetectionStatus messages from the "value1" and "value2" input
+ * data ports. The behavior succeeds if they are identical and fails if they are different.
+ *
+ * | Data Port Name | Port Type | Object Type                            |
+ * | -------------- | --------- | -------------------------------------- |
+ * | value1         | input     | epick_msgs::msg::ObjectDetectionStatus |
+ * | value2         | input     | epick_msgs::msg::ObjectDetectionStatus |
+ */
 class CompareEpickObjectDetectionStatus final : public BT::SyncActionNode
 {
 public:

--- a/epick_moveit_studio/include/epick_moveit_studio/compare_epick_object_detection_status.hpp
+++ b/epick_moveit_studio/include/epick_moveit_studio/compare_epick_object_detection_status.hpp
@@ -26,29 +26,19 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <behaviortree_cpp/bt_factory.h>
-#include <moveit_studio_behavior_interface/behavior_context.hpp>
-#include <moveit_studio_behavior_interface/shared_resources_node_loader.hpp>
-#include <pluginlib/class_list_macros.hpp>
+#pragma once
 
-// Include headers for your custom Behaviors
-#include <epick_moveit_studio/compare_epick_object_detection_status.hpp>
-#include <epick_moveit_studio/get_epick_object_detection_status.hpp>
+#include <behaviortree_cpp/action_node.h>
 
 namespace epick_moveit_studio
 {
-class BehaviorLoader : public moveit_studio::behaviors::SharedResourcesNodeLoaderBase
+class CompareEpickObjectDetectionStatus final : public BT::SyncActionNode
 {
 public:
-  void registerBehaviors(BT::BehaviorTreeFactory& factory,
-                         const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources) override
-  {
-      moveit_studio::behaviors::registerBehavior<CompareEpickObjectDetectionStatus>(factory, "CompareEpickObjectDetectionStatus");
-      moveit_studio::behaviors::registerBehavior<GetEpickObjectDetectionStatus>(factory, "GetEpickObjectDetectionStatus", shared_resources);
-  }
+  CompareEpickObjectDetectionStatus(const std::string& name, const BT::NodeConfiguration& config);
+
+  static BT::PortsList providedPorts();
+
+  BT::NodeStatus tick() override;
 };
-
-}  // epick_moveit_studio
-
-PLUGINLIB_EXPORT_CLASS(epick_moveit_studio::BehaviorLoader,
-                       moveit_studio::behaviors::SharedResourcesNodeLoaderBase);
+}  // namespace epick_moveit_studio

--- a/epick_moveit_studio/include/epick_moveit_studio/compare_epick_object_detection_status.hpp
+++ b/epick_moveit_studio/include/epick_moveit_studio/compare_epick_object_detection_status.hpp
@@ -35,7 +35,7 @@
 namespace BT
 {
 /**
- * @brief Template specialization of convertToString to parse a string as an epick_msgs::msg::ObjectDetectionStatus.
+ * @brief Template specialization of convertFromString to parse a string as an epick_msgs::msg::ObjectDetectionStatus.
  * @details This allows setting one of the input ports of CompareEpickObjectDetectionStatus by typing a string.
  * @param str Input string to convert.
  * @return epick_msgs::msg::ObjectDetectionStatus

--- a/epick_moveit_studio/include/epick_moveit_studio/get_epick_object_detection_status.hpp
+++ b/epick_moveit_studio/include/epick_moveit_studio/get_epick_object_detection_status.hpp
@@ -28,46 +28,7 @@
 
 #pragma once
 
-#include <behaviortree_cpp/exceptions.h>
-#include <epick_msgs/msg/detail/object_detection_status__builder.hpp>
-#include <epick_msgs/msg/detail/object_detection_status__struct.hpp>
 #include <moveit_studio_behavior_interface/get_message_from_topic.hpp>
-
-#include <epick_msgs/msg/object_detection_status.hpp>
-
-namespace BT
-{
-/**
- * @brief Template specialization of convertToString to split a string into an epick_msgs::msg::ObjectDetectionStatus.
- * @param str Input string to convert.
- * @return epick_msgs::msg::ObjectDetectionStatus
- */
-template <>
-inline epick_msgs::msg::ObjectDetectionStatus convertFromString<epick_msgs::msg::ObjectDetectionStatus>(BT::StringView str)
-{
-  using Status = epick_msgs::msg::ObjectDetectionStatus;
-  if (str == "OBJECT_DETECTED_AT_MIN_PRESSURE")
-  {
-    return epick_msgs::build<Status>().status(Status::OBJECT_DETECTED_AT_MIN_PRESSURE);
-  }
-  else if (str == "OBJECT_DETECTED_AT_MAX_PRESSURE")
-  {
-    return epick_msgs::build<Status>().status(Status::OBJECT_DETECTED_AT_MAX_PRESSURE);
-  }
-  else if (str == "NO_OBJECT_DETECTED")
-  {
-    return epick_msgs::build<Status>().status(Status::NO_OBJECT_DETECTED);
-  }
-  else if (str == "UNKNOWN")
-  {
-    return epick_msgs::build<Status>().status(Status::UNKNOWN);
-  }
-  else
-  {
-    throw BT::RuntimeError(std::string("Invalid input: ").append(str));
-  }
-}
-}  // namespace BT
 
 namespace epick_moveit_studio
 {

--- a/epick_moveit_studio/include/epick_moveit_studio/get_epick_object_detection_status.hpp
+++ b/epick_moveit_studio/include/epick_moveit_studio/get_epick_object_detection_status.hpp
@@ -50,7 +50,7 @@ inline epick_msgs::msg::ObjectDetectionStatus convertFromString<epick_msgs::msg:
   {
     return epick_msgs::build<Status>().status(Status::OBJECT_DETECTED_AT_MIN_PRESSURE);
   }
-  else if (str == "OBJECT_DETECTED_AT_MIN_PRESSURE")
+  else if (str == "OBJECT_DETECTED_AT_MAX_PRESSURE")
   {
     return epick_msgs::build<Status>().status(Status::OBJECT_DETECTED_AT_MAX_PRESSURE);
   }

--- a/epick_moveit_studio/include/epick_moveit_studio/get_epick_object_detection_status.hpp
+++ b/epick_moveit_studio/include/epick_moveit_studio/get_epick_object_detection_status.hpp
@@ -34,21 +34,22 @@
 namespace epick_moveit_studio
 {
 /**
- * @brief Capture a point cloud. The name of the topic containing the point cloud is set through the
- * "topic_name" parameter, and the resulting point cloud is available on the "message_out" output
- * port.
+ * @brief Capture a epick_msgs::msg::ObjectDetectionStatus message.
+ * @details The topic to monitor is set through the "topic_name" parameter, and the resulting message is available on
+ * the "message_out" output port.
  *
  * @details
- * | Data Port Name | Port Type | Object Type                   |
- * | -------------- | --------- | ----------------------------- |
- * | topic_name     | input     | std::string                   |
- * | message_out    | output    | sensor_msgs::msg::PointCloud2 |
+ * | Data Port Name | Port Type | Object Type                            |
+ * | -------------- | --------- | -------------------------------------- |
+ * | topic_name     | input     | std::string                            |
+ * | message_out    | output    | epick_msgs::msg::ObjectDetectionStatus |
  */
-class GetEpickObjectDetectionStatus final : public moveit_studio::behaviors::GetMessageFromTopicBehaviorBase<epick_msgs::msg::ObjectDetectionStatus>
+class GetEpickObjectDetectionStatus final
+  : public moveit_studio::behaviors::GetMessageFromTopicBehaviorBase<epick_msgs::msg::ObjectDetectionStatus>
 {
 public:
   GetEpickObjectDetectionStatus(const std::string& name, const BT::NodeConfiguration& config,
-                const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
+                                const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
 
 private:
   fp::Result<std::chrono::duration<double>> getWaitForMessageTimeout() override;

--- a/epick_moveit_studio/include/epick_moveit_studio/get_epick_object_detection_status.hpp
+++ b/epick_moveit_studio/include/epick_moveit_studio/get_epick_object_detection_status.hpp
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <epick_msgs/msg/object_detection_status.hpp>
 #include <moveit_studio_behavior_interface/get_message_from_topic.hpp>
 
 namespace epick_moveit_studio
@@ -50,8 +51,7 @@ public:
                 const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
 
 private:
-  /** @brief Override getWaitForMessageTimeout to allow failing if no point cloud is received within the expected duration. */
-  // fp::Result<std::chrono::duration<double>> getWaitForMessageTimeout() override;
+  fp::Result<std::chrono::duration<double>> getWaitForMessageTimeout() override;
 
   /** @brief Classes derived from AsyncBehaviorBase must implement getFuture() so that it returns a shared_future class member */
   std::shared_future<fp::Result<bool>>& getFuture() override

--- a/epick_moveit_studio/include/epick_moveit_studio/get_epick_object_detection_status.hpp
+++ b/epick_moveit_studio/include/epick_moveit_studio/get_epick_object_detection_status.hpp
@@ -1,0 +1,104 @@
+// Copyright (c) 2023 PickNik, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <behaviortree_cpp/exceptions.h>
+#include <epick_msgs/msg/detail/object_detection_status__builder.hpp>
+#include <epick_msgs/msg/detail/object_detection_status__struct.hpp>
+#include <moveit_studio_behavior_interface/get_message_from_topic.hpp>
+
+#include <epick_msgs/msg/object_detection_status.hpp>
+
+namespace BT
+{
+/**
+ * @brief Template specialization of convertToString to split a string into an epick_msgs::msg::ObjectDetectionStatus.
+ * @param str Input string to convert.
+ * @return epick_msgs::msg::ObjectDetectionStatus
+ */
+template <>
+inline epick_msgs::msg::ObjectDetectionStatus convertFromString<epick_msgs::msg::ObjectDetectionStatus>(BT::StringView str)
+{
+  using Status = epick_msgs::msg::ObjectDetectionStatus;
+  if (str == "OBJECT_DETECTED_AT_MIN_PRESSURE")
+  {
+    return epick_msgs::build<Status>().status(Status::OBJECT_DETECTED_AT_MIN_PRESSURE);
+  }
+  else if (str == "OBJECT_DETECTED_AT_MIN_PRESSURE")
+  {
+    return epick_msgs::build<Status>().status(Status::OBJECT_DETECTED_AT_MAX_PRESSURE);
+  }
+  else if (str == "NO_OBJECT_DETECTED")
+  {
+    return epick_msgs::build<Status>().status(Status::NO_OBJECT_DETECTED);
+  }
+  else if (str == "UNKNOWN")
+  {
+    return epick_msgs::build<Status>().status(Status::UNKNOWN);
+  }
+  else
+  {
+    throw BT::RuntimeError(std::string("Invalid input: ").append(str));
+  }
+}
+}  // namespace BT
+
+namespace epick_moveit_studio
+{
+/**
+ * @brief Capture a point cloud. The name of the topic containing the point cloud is set through the
+ * "topic_name" parameter, and the resulting point cloud is available on the "message_out" output
+ * port.
+ *
+ * @details
+ * | Data Port Name | Port Type | Object Type                   |
+ * | -------------- | --------- | ----------------------------- |
+ * | topic_name     | input     | std::string                   |
+ * | message_out    | output    | sensor_msgs::msg::PointCloud2 |
+ */
+class GetEpickObjectDetectionStatus final : public moveit_studio::behaviors::GetMessageFromTopicBehaviorBase<epick_msgs::msg::ObjectDetectionStatus>
+{
+public:
+  GetEpickObjectDetectionStatus(const std::string& name, const BT::NodeConfiguration& config,
+                const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
+
+private:
+  /** @brief Override getWaitForMessageTimeout to allow failing if no point cloud is received within the expected duration. */
+  // fp::Result<std::chrono::duration<double>> getWaitForMessageTimeout() override;
+
+  /** @brief Classes derived from AsyncBehaviorBase must implement getFuture() so that it returns a shared_future class member */
+  std::shared_future<fp::Result<bool>>& getFuture() override
+  {
+    return future_;
+  }
+
+  /** @brief Classes derived from AsyncBehaviorBase must have this shared_future as a class member */
+  std::shared_future<fp::Result<bool>> future_;
+};
+}  // namespace epick_moveit_studio

--- a/epick_moveit_studio/package.xml
+++ b/epick_moveit_studio/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>epick_moveit_studio</name>
+  <version>0.0.1</version>
+  <description>
+    epick_moveit_studio
+  </description>
+  <maintainer email="joseph.schornak@picknik.ai">Joe Schornak</maintainer>
+  <author email="joseph.schornak@picknik.ai">Joe Schornak</author>
+
+  <license>BSD-3-Clause</license>
+
+  <url type="website">https://github.com/PickNikRobotics/</url>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>builtin_interfaces</buildtool_depend>
+
+  <build_depend>ament_lint_auto</build_depend>
+
+  <depend>epick_msgs</depend>
+  <depend>moveit_studio_behavior_interface</depend>
+  <depend>pluginlib</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/epick_moveit_studio/src/behavior_loader.cpp
+++ b/epick_moveit_studio/src/behavior_loader.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2023 PickNik, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <behaviortree_cpp/bt_factory.h>
+#include <moveit_studio_behavior_interface/behavior_context.hpp>
+#include <moveit_studio_behavior_interface/shared_resources_node_loader.hpp>
+#include <pluginlib/class_list_macros.hpp>
+
+// Include headers for your custom Behaviors
+#include <epick_msgs/msg/object_detection_status.hpp>
+#include <epick_moveit_studio/get_epick_object_detection_status.hpp>
+
+namespace epick_moveit_studio
+{
+class BehaviorLoader : public moveit_studio::behaviors::SharedResourcesNodeLoaderBase
+{
+public:
+  void registerBehaviors(BT::BehaviorTreeFactory& factory,
+                         const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources) override
+  {
+      moveit_studio::behaviors::registerBehavior<GetEpickObjectDetectionStatus>(factory, "GetEpickObjectDetectionStatus", shared_resources);
+  }
+};
+
+}  // epick_moveit_studio
+
+PLUGINLIB_EXPORT_CLASS(epick_moveit_studio::BehaviorLoader,
+                       moveit_studio::behaviors::SharedResourcesNodeLoaderBase);

--- a/epick_moveit_studio/src/behavior_loader.cpp
+++ b/epick_moveit_studio/src/behavior_loader.cpp
@@ -27,6 +27,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include <behaviortree_cpp/bt_factory.h>
+#include <memory>
 #include <moveit_studio_behavior_interface/behavior_context.hpp>
 #include <moveit_studio_behavior_interface/shared_resources_node_loader.hpp>
 #include <pluginlib/class_list_macros.hpp>
@@ -43,12 +44,13 @@ public:
   void registerBehaviors(BT::BehaviorTreeFactory& factory,
                          const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources) override
   {
-      moveit_studio::behaviors::registerBehavior<CompareEpickObjectDetectionStatus>(factory, "CompareEpickObjectDetectionStatus");
-      moveit_studio::behaviors::registerBehavior<GetEpickObjectDetectionStatus>(factory, "GetEpickObjectDetectionStatus", shared_resources);
+    moveit_studio::behaviors::registerBehavior<CompareEpickObjectDetectionStatus>(factory,
+                                                                                  "CompareEpickObjectDetectionStatus");
+    moveit_studio::behaviors::registerBehavior<GetEpickObjectDetectionStatus>(factory, "GetEpickObjectDetectionStatus",
+                                                                              shared_resources);
   }
 };
 
-}  // epick_moveit_studio
+}  // namespace epick_moveit_studio
 
-PLUGINLIB_EXPORT_CLASS(epick_moveit_studio::BehaviorLoader,
-                       moveit_studio::behaviors::SharedResourcesNodeLoaderBase);
+PLUGINLIB_EXPORT_CLASS(epick_moveit_studio::BehaviorLoader, moveit_studio::behaviors::SharedResourcesNodeLoaderBase);

--- a/epick_moveit_studio/src/compare_epick_object_detection_status.cpp
+++ b/epick_moveit_studio/src/compare_epick_object_detection_status.cpp
@@ -35,21 +35,21 @@
 
 namespace
 {
-  constexpr auto kPortIDValue1 = "value1";
-  constexpr auto kPortIDValue2 = "value2";
-}
+constexpr auto kPortIDValue1 = "value1";
+constexpr auto kPortIDValue2 = "value2";
+}  // namespace
 
 namespace epick_moveit_studio
 {
-CompareEpickObjectDetectionStatus::CompareEpickObjectDetectionStatus(const std::string& name, const BT::NodeConfiguration& config)
+CompareEpickObjectDetectionStatus::CompareEpickObjectDetectionStatus(const std::string& name,
+                                                                     const BT::NodeConfiguration& config)
   : BT::SyncActionNode(name, config)
 {
 }
 
 BT::PortsList CompareEpickObjectDetectionStatus::providedPorts()
 {
-  return BT::PortsList
-  {
+  return BT::PortsList{
     BT::InputPort<epick_msgs::msg::ObjectDetectionStatus>(kPortIDValue1),
     BT::InputPort<epick_msgs::msg::ObjectDetectionStatus>(kPortIDValue2),
   };
@@ -75,4 +75,3 @@ BT::NodeStatus CompareEpickObjectDetectionStatus::tick()
   }
 }
 }  // namespace epick_moveit_studio
-

--- a/epick_moveit_studio/src/compare_epick_object_detection_status.cpp
+++ b/epick_moveit_studio/src/compare_epick_object_detection_status.cpp
@@ -29,8 +29,6 @@
 #include <behaviortree_cpp/action_node.h>
 #include <behaviortree_cpp/basic_types.h>
 #include <epick_moveit_studio/compare_epick_object_detection_status.hpp>
-
-#include <epick_msgs/msg/detail/object_detection_status__struct.hpp>
 #include <epick_msgs/msg/object_detection_status.hpp>
 
 namespace

--- a/epick_moveit_studio/src/get_epick_object_detection_status.cpp
+++ b/epick_moveit_studio/src/get_epick_object_detection_status.cpp
@@ -31,11 +31,11 @@
 #include <epick_msgs/msg/object_detection_status.hpp>
 #include <moveit_studio_behavior_interface/impl/get_message_from_topic_impl.hpp>
 
-// namespace
-// {
-// /** @brief Maximum duration to wait for a point cloud to be published before failing. */
-// constexpr auto kWaitForPointCloudDuration = std::chrono::seconds{ 5 };
-// }  // namespace
+namespace
+{
+/** @brief Maximum duration to wait for a message to be published before failing. */
+constexpr auto kWaitDuration = std::chrono::seconds{ 1 };
+}  // namespace
 
 namespace epick_moveit_studio
 {
@@ -45,10 +45,10 @@ GetEpickObjectDetectionStatus::GetEpickObjectDetectionStatus(const std::string& 
 {
 }
 
-// fp::Result<std::chrono::duration<double>> GetEpickObjectDetectionStatus::getWaitForMessageTimeout()
-// {
-//   return kWaitForPointCloudDuration;
-// }
+fp::Result<std::chrono::duration<double>> GetEpickObjectDetectionStatus::getWaitForMessageTimeout()
+{
+  return kWaitDuration;
+}
 
 }  // namespace epick_moveit_studio
 

--- a/epick_moveit_studio/src/get_epick_object_detection_status.cpp
+++ b/epick_moveit_studio/src/get_epick_object_detection_status.cpp
@@ -39,9 +39,11 @@ constexpr auto kWaitDuration = std::chrono::seconds{ 1 };
 
 namespace epick_moveit_studio
 {
-GetEpickObjectDetectionStatus::GetEpickObjectDetectionStatus(const std::string& name, const BT::NodeConfiguration& config,
-                             const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources)
-  : moveit_studio::behaviors::GetMessageFromTopicBehaviorBase<epick_msgs::msg::ObjectDetectionStatus>(name, config, shared_resources)
+GetEpickObjectDetectionStatus::GetEpickObjectDetectionStatus(
+    const std::string& name, const BT::NodeConfiguration& config,
+    const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources)
+  : moveit_studio::behaviors::GetMessageFromTopicBehaviorBase<epick_msgs::msg::ObjectDetectionStatus>(name, config,
+                                                                                                      shared_resources)
 {
 }
 

--- a/epick_moveit_studio/src/get_epick_object_detection_status.cpp
+++ b/epick_moveit_studio/src/get_epick_object_detection_status.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2023 PickNik, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <epick_moveit_studio/get_epick_object_detection_status.hpp>
+
+#include <epick_msgs/msg/object_detection_status.hpp>
+#include <moveit_studio_behavior_interface/impl/get_message_from_topic_impl.hpp>
+
+// namespace
+// {
+// /** @brief Maximum duration to wait for a point cloud to be published before failing. */
+// constexpr auto kWaitForPointCloudDuration = std::chrono::seconds{ 5 };
+// }  // namespace
+
+namespace epick_moveit_studio
+{
+GetEpickObjectDetectionStatus::GetEpickObjectDetectionStatus(const std::string& name, const BT::NodeConfiguration& config,
+                             const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources)
+  : moveit_studio::behaviors::GetMessageFromTopicBehaviorBase<epick_msgs::msg::ObjectDetectionStatus>(name, config, shared_resources)
+{
+}
+
+// fp::Result<std::chrono::duration<double>> GetEpickObjectDetectionStatus::getWaitForMessageTimeout()
+// {
+//   return kWaitForPointCloudDuration;
+// }
+
+}  // namespace epick_moveit_studio
+
+template class moveit_studio::behaviors::GetMessageFromTopicBehaviorBase<epick_msgs::msg::ObjectDetectionStatus>;

--- a/epick_moveit_studio/test/CMakeLists.txt
+++ b/epick_moveit_studio/test/CMakeLists.txt
@@ -1,3 +1,4 @@
+find_package(ament_cmake_gmock REQUIRED)
 find_package(ament_cmake_gtest REQUIRED)
 
 ament_add_gtest(test_load_behaviors
@@ -5,3 +6,6 @@ ament_add_gtest(test_load_behaviors
 )
 ament_target_dependencies(test_load_behaviors moveit_studio_behavior_interface pluginlib)
 target_link_libraries(test_load_behaviors moveit_studio_behavior_interface::shared_resources_node)
+
+ament_add_gmock(test_compare_epick_object_detection_status test_compare_epick_object_detection_status.cpp)
+target_link_libraries(test_compare_epick_object_detection_status epick_behaviors)

--- a/epick_moveit_studio/test/CMakeLists.txt
+++ b/epick_moveit_studio/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+find_package(ament_cmake_gtest REQUIRED)
+
+ament_add_gtest(test_load_behaviors
+  test_load_behaviors.cpp
+)
+ament_target_dependencies(test_load_behaviors moveit_studio_behavior_interface pluginlib)
+target_link_libraries(test_load_behaviors moveit_studio_behavior_interface::shared_resources_node)

--- a/epick_moveit_studio/test/test_compare_epick_object_detection_status.cpp
+++ b/epick_moveit_studio/test/test_compare_epick_object_detection_status.cpp
@@ -1,0 +1,156 @@
+// Copyright (c) 2023 PickNik, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <behaviortree_cpp/basic_types.h>
+#include <behaviortree_cpp/exceptions.h>
+#include <epick_moveit_studio/compare_epick_object_detection_status.hpp>
+#include <epick_msgs/msg/object_detection_status.hpp>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace
+{
+constexpr auto kPortIDValue1 = "value1";
+constexpr auto kPortIDValue2 = "value2";
+
+using ObjectDetectionStatus = epick_msgs::msg::ObjectDetectionStatus;
+using ::testing::Eq;
+using ::testing::Throw;
+}  // namespace
+
+namespace epick_moveit_studio
+{
+class CompareEpickObjectDetectionStatusTest : public ::testing::Test
+{
+public:
+  void SetUp() override
+  {
+    BT::NodeConfiguration config;
+    for (const auto& port : CompareEpickObjectDetectionStatus::providedPorts())
+    {
+      if (port.second.direction() == BT::PortDirection::INPUT || port.second.direction() == BT::PortDirection::INOUT)
+      {
+        config.input_ports.try_emplace(port.first, "=");
+      }
+      if (port.second.direction() == BT::PortDirection::OUTPUT || port.second.direction() == BT::PortDirection::INOUT)
+      {
+        config.output_ports.try_emplace(port.first, "=");
+      }
+    }
+
+    config.blackboard = BT::Blackboard::create();
+    blackboard_ptr = config.blackboard.get();
+    behavior = std::make_unique<CompareEpickObjectDetectionStatus>("CompareEpickObjectDetectionStatus", config);
+  }
+
+  BT::Blackboard* blackboard_ptr;
+  std::unique_ptr<CompareEpickObjectDetectionStatus> behavior;
+};
+
+TEST_F(CompareEpickObjectDetectionStatusTest, FailureIfValue1Missing)
+{
+  // GIVEN the input port for the second value is not set
+
+  // GIVEN valid input for the first value
+  blackboard_ptr->set(kPortIDValue1, ObjectDetectionStatus());
+
+  // WHEN the behavior is ticked
+  // THEN the behavior fails
+  ASSERT_EQ(behavior->executeTick(), BT::NodeStatus::FAILURE);
+}
+
+TEST_F(CompareEpickObjectDetectionStatusTest, FailureIfValue2Missing)
+{
+  // GIVEN the input port for the first value is not set
+
+  // GIVEN valid input for the second value
+  blackboard_ptr->set(kPortIDValue2, ObjectDetectionStatus());
+
+  // WHEN the behavior is ticked
+  // THEN the behavior fails
+  ASSERT_EQ(behavior->executeTick(), BT::NodeStatus::FAILURE);
+}
+
+TEST_F(CompareEpickObjectDetectionStatusTest, SucceedsIfValuesMatch)
+{
+  // GIVEN valid and matching inputs
+  blackboard_ptr->set(kPortIDValue1,
+                      epick_msgs::build<ObjectDetectionStatus>().status(ObjectDetectionStatus::NO_OBJECT_DETECTED));
+  blackboard_ptr->set(kPortIDValue2,
+                      epick_msgs::build<ObjectDetectionStatus>().status(ObjectDetectionStatus::NO_OBJECT_DETECTED));
+
+  // WHEN the behavior is ticked
+  // THEN it succeeds
+  ASSERT_EQ(behavior->executeTick(), BT::NodeStatus::SUCCESS);
+}
+
+TEST_F(CompareEpickObjectDetectionStatusTest, SucceedsIfValuesMatchStringConversion)
+{
+  // GIVEN valid inputs which are equivalent to the same value, where one is an ObjectDetectionStatus message and the other is a string
+  blackboard_ptr->set(kPortIDValue1, epick_msgs::build<ObjectDetectionStatus>().status(
+                                         ObjectDetectionStatus::OBJECT_DETECTED_AT_MAX_PRESSURE));
+  blackboard_ptr->set(kPortIDValue2, "OBJECT_DETECTED_AT_MAX_PRESSURE");
+
+  // WHEN the behavior is ticked
+  // THEN it succeeds
+  ASSERT_EQ(behavior->executeTick(), BT::NodeStatus::SUCCESS);
+}
+
+TEST_F(CompareEpickObjectDetectionStatusTest, FailureIfValuesMismatch)
+{
+  // GIVEN valid and different inputs
+  blackboard_ptr->set(kPortIDValue1,
+                      epick_msgs::build<ObjectDetectionStatus>().status(ObjectDetectionStatus::NO_OBJECT_DETECTED));
+  blackboard_ptr->set(kPortIDValue2, epick_msgs::build<ObjectDetectionStatus>().status(
+                                         ObjectDetectionStatus::OBJECT_DETECTED_AT_MIN_PRESSURE));
+
+  // WHEN the behavior is ticked
+  // THEN it fails
+  ASSERT_EQ(behavior->executeTick(), BT::NodeStatus::FAILURE);
+}
+
+TEST(CompareEpickObjectDetectionStatus, TestConvertFromString)
+{
+  // WHEN we provide strings corresponding to the status enums
+  // THEN each string is converted into the correct enum
+  EXPECT_THAT(BT::convertFromString<ObjectDetectionStatus>("NO_OBJECT_DETECTED"),
+              Eq(epick_msgs::build<ObjectDetectionStatus>().status(ObjectDetectionStatus::NO_OBJECT_DETECTED)));
+  EXPECT_THAT(
+      BT::convertFromString<ObjectDetectionStatus>("OBJECT_DETECTED_AT_MIN_PRESSURE"),
+      Eq(epick_msgs::build<ObjectDetectionStatus>().status(ObjectDetectionStatus::OBJECT_DETECTED_AT_MIN_PRESSURE)));
+  EXPECT_THAT(
+      BT::convertFromString<ObjectDetectionStatus>("OBJECT_DETECTED_AT_MAX_PRESSURE"),
+      Eq(epick_msgs::build<ObjectDetectionStatus>().status(ObjectDetectionStatus::OBJECT_DETECTED_AT_MAX_PRESSURE)));
+  EXPECT_THAT(BT::convertFromString<ObjectDetectionStatus>("UNKNOWN"),
+              Eq(epick_msgs::build<ObjectDetectionStatus>().status(ObjectDetectionStatus::UNKNOWN)));
+
+  // WHEN we provide a string that does not correspond to any status enum
+  // THEN an exception is thrown
+  EXPECT_THROW((void)BT::convertFromString<ObjectDetectionStatus>("some_nonsensical_input"), BT::RuntimeError);
+}
+}  // namespace epick_moveit_studio

--- a/epick_moveit_studio/test/test_load_behaviors.cpp
+++ b/epick_moveit_studio/test/test_load_behaviors.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2023 PickNik, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <behaviortree_cpp/bt_factory.h>
+#include <gtest/gtest.h>
+#include <pluginlib/class_loader.hpp>
+#include <rclcpp/node.hpp>
+
+#include <moveit_studio_behavior_interface/shared_resources_node_loader.hpp>
+
+namespace
+{
+constexpr auto kBehaviorInterfacePackageName = "moveit_studio_behavior_interface";
+constexpr auto kBehaviorBaseClassName = "moveit_studio::behaviors::SharedResourcesNodeLoaderBase";
+constexpr auto kTestBehaviorName = "test_behavior_name";
+}  // namespace
+
+/**
+ * @brief This test makes sure that the Behaviors provided in this package can be successfully registered and
+ * instantiated by the behavior tree factory.
+ */
+TEST(EpickBehaviors, LoadBehaviorPlugins)
+{
+  pluginlib::ClassLoader<moveit_studio::behaviors::SharedResourcesNodeLoaderBase> class_loader(
+      kBehaviorInterfacePackageName, kBehaviorBaseClassName);
+
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto shared_resources = std::make_shared<moveit_studio::behaviors::BehaviorContext>(node);
+
+  BT::BehaviorTreeFactory factory;
+  {
+    auto plugin_instance =
+        class_loader.createUniqueInstance("epick_moveit_studio::BehaviorLoader");
+    ASSERT_NO_THROW(plugin_instance->registerBehaviors(factory, shared_resources));
+  }
+
+  // Test that ClassLoader is able to find and instantiate each behavior using the package's plugin description info.
+  EXPECT_NO_THROW((void)factory.instantiateTreeNode(kTestBehaviorName, "GetEpickObjectDetectionStatus", BT::NodeConfiguration()));
+}
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/epick_moveit_studio/test/test_load_behaviors.cpp
+++ b/epick_moveit_studio/test/test_load_behaviors.cpp
@@ -54,14 +54,15 @@ TEST(EpickBehaviors, LoadBehaviorPlugins)
 
   BT::BehaviorTreeFactory factory;
   {
-    auto plugin_instance =
-        class_loader.createUniqueInstance("epick_moveit_studio::BehaviorLoader");
+    auto plugin_instance = class_loader.createUniqueInstance("epick_moveit_studio::BehaviorLoader");
     ASSERT_NO_THROW(plugin_instance->registerBehaviors(factory, shared_resources));
   }
 
   // Test that ClassLoader is able to find and instantiate each behavior using the package's plugin description info.
-  EXPECT_NO_THROW((void)factory.instantiateTreeNode(kTestBehaviorName, "CompareEpickObjectDetectionStatus", BT::NodeConfiguration()));
-  EXPECT_NO_THROW((void)factory.instantiateTreeNode(kTestBehaviorName, "GetEpickObjectDetectionStatus", BT::NodeConfiguration()));
+  EXPECT_NO_THROW((void)factory.instantiateTreeNode(kTestBehaviorName, "CompareEpickObjectDetectionStatus",
+                                                    BT::NodeConfiguration()));
+  EXPECT_NO_THROW(
+      (void)factory.instantiateTreeNode(kTestBehaviorName, "GetEpickObjectDetectionStatus", BT::NodeConfiguration()));
 }
 
 int main(int argc, char** argv)

--- a/epick_moveit_studio/test/test_load_behaviors.cpp
+++ b/epick_moveit_studio/test/test_load_behaviors.cpp
@@ -60,6 +60,7 @@ TEST(EpickBehaviors, LoadBehaviorPlugins)
   }
 
   // Test that ClassLoader is able to find and instantiate each behavior using the package's plugin description info.
+  EXPECT_NO_THROW((void)factory.instantiateTreeNode(kTestBehaviorName, "CompareEpickObjectDetectionStatus", BT::NodeConfiguration()));
   EXPECT_NO_THROW((void)factory.instantiateTreeNode(kTestBehaviorName, "GetEpickObjectDetectionStatus", BT::NodeConfiguration()));
 }
 


### PR DESCRIPTION
## Description

- Add `epick_moveit_studio` package, which allows interacting with Epick-specific messages as part of behavior trees in [MoveIt Studio](https://picknik.ai/studio/).
  - `GetEpickObjectDetectionStatus` subscribes to the topic on which the Epick status publisher controller is broadcasting vacuum state messages. When it receives a message, it sets the message to an output data port so other behaviors can use it.
  - `CompareEpickObjectDetectionStatus` compares two status messages. If they are the same, the behavior succeeds. If they are different, the behavior fails. This allows the control logic of a behavior tree to make decisions based on vacuum status.

## TODO
- [x] More tests