### PR TITLE
Replace fp::Result with tl::expected

### DIFF
--- a/epick_moveit_studio/include/epick_moveit_studio/get_epick_object_detection_status.hpp
+++ b/epick_moveit_studio/include/epick_moveit_studio/get_epick_object_detection_status.hpp
@@ -52,15 +52,15 @@ public:
                                 const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
 
 private:
-  fp::Result<std::chrono::duration<double>> getWaitForMessageTimeout() override;
+  tl::expected<std::chrono::duration<double>, std::string> getWaitForMessageTimeout() override;
 
   /** @brief Classes derived from AsyncBehaviorBase must implement getFuture() so that it returns a shared_future class member */
-  std::shared_future<fp::Result<bool>>& getFuture() override
+  std::shared_future<tl::expected<bool, std::string>>& getFuture() override
   {
     return future_;
   }
 
   /** @brief Classes derived from AsyncBehaviorBase must have this shared_future as a class member */
-  std::shared_future<fp::Result<bool>> future_;
+  std::shared_future<tl::expected<bool, std::string>> future_;
 };
 }  // namespace epick_moveit_studio

--- a/epick_moveit_studio/src/get_epick_object_detection_status.cpp
+++ b/epick_moveit_studio/src/get_epick_object_detection_status.cpp
@@ -47,7 +47,7 @@ GetEpickObjectDetectionStatus::GetEpickObjectDetectionStatus(
 {
 }
 
-fp::Result<std::chrono::duration<double>> GetEpickObjectDetectionStatus::getWaitForMessageTimeout()
+tl::expected<std::chrono::duration<double>, std::string> GetEpickObjectDetectionStatus::getWaitForMessageTimeout()
 {
   return kWaitDuration;
 }


### PR DESCRIPTION
This is required to use the Behaviors in this repo with MoveIt Studio 3.0 and newer.