### PR TITLE
Update epick_gripper_controller_allocator.cpp

### DIFF
--- a/epick_moveit_plugin/src/epick_gripper_controller_allocator.cpp
+++ b/epick_moveit_plugin/src/epick_gripper_controller_allocator.cpp
@@ -56,7 +56,7 @@ public:
                                                              const std::string& name,
                                                              const std::vector<std::string>& /* resources */) override
   {
-    return std::make_shared<moveit_simple_controller_manager::GripperControllerHandle>(node, name,
+    return std::make_shared<moveit_simple_controller_manager::GripperCommandControllerHandle>(node, name,
                                                                                        kGripperCommandAction);
   }
 };


### PR DESCRIPTION
building the module with Ubuntu 24.04 and jazzy fails.

This change fixes the build.